### PR TITLE
Add S3-compatible HTTP gateway (candybox-s3-gateway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,5 +246,6 @@ hard fencing/handover scenarios. No mocking frameworks are used anywhere.
 | `candybox-protocol` | The framed TCP wire protocol and transport. |
 | `candybox-server` | The storage node: wires the engine behind the protocol, plus the runnable entrypoint, health/metrics, and ownership. |
 | `candybox-client` | The thin client library and the `candybox` command-line tool. |
+| `candybox-s3-gateway` | An anonymous, path-style, S3-compatible HTTP gateway (Netty) that translates the S3 REST/XML API onto the client. Stateless; runs behind an HTTP(S) load balancer. See `S3_GATEWAY_PLAN.md`. |
 | `candybox-dist` | Packages the runnable distribution (`bin/ lib/ conf/`) and the Docker/Kubernetes assets. |
 | `candybox-integration-tests` | End-to-end tests on embedded BookKeeper + ZooKeeper. |

--- a/S3_GATEWAY_PLAN.md
+++ b/S3_GATEWAY_PLAN.md
@@ -1,0 +1,447 @@
+# Candybox S3 Gateway — Implementation Plan
+
+Status: **v1 implemented** (module `candybox-s3-gateway`) · Last updated: 2026-05-29
+
+> **Implemented in v1:** the standalone Netty gateway module, anonymous path-style addressing, bucket
+> CRUD + `ListBuckets`, single-shot `PutObject`/`GetObject`/`HeadObject`/`DeleteObject`, `CopyObject`
+> (same-bucket), batch `DeleteObjects`, `ListObjectsV2`/V1 with delimiter rollup + continuation tokens,
+> deterministic CRC32C ETag, the S3 error model, `aws-chunked` decoding, ignored auth, and the canned
+> startup-probe subresources. Launch with `bin/candybox-s3-gateway`. Unit tests live in the module;
+> `S3GatewayIT` drives it end-to-end over a real node. **Deferred** (per §16): multipart upload, real
+> MD5 ETags, Range GET, virtual-host addressing, SigV4.
+
+This document is the concrete implementation plan for an **S3-compatible HTTP gateway** in front of
+Candybox. It is a *translation layer*: it speaks the S3 REST/XML protocol to clients and the existing
+Candybox TCP wire protocol (via `CandyboxClient`) to the cluster. It introduces **no new on-ledger or
+wire format** and depends on no new Candybox engine features for v1.
+
+Read `DESIGN.md` for the storage architecture and `README.md` for the module map. This plan does not
+change either; it adds one new leaf module.
+
+---
+
+## 1. Scope
+
+### In scope (v1)
+
+- A standalone, **stateless** gateway process (`candybox-s3-gateway`) built on **Netty**.
+- **Anonymous** access only — no request signing/verification (SigV4 ignored, see §10).
+- **Path-style** bucket addressing only: `https://s3.host/<bucket>/<key>` (see §5).
+- Bucket ops: `CreateBucket`, `DeleteBucket`, `HeadBucket`, `ListBuckets`.
+- Object ops: single-shot `PutObject`, `GetObject` (full object), `HeadObject`, `DeleteObject`,
+  `CopyObject`, `DeleteObjects` (batch).
+- `ListObjectsV2` (and V1 `marker` compatibility) with `prefix`, `delimiter`, `max-keys`,
+  pagination, and synthesized `CommonPrefixes`.
+- **Deterministic ETag derived from the stored CRC32C** (see §8).
+- S3-shaped XML responses and error bodies (see §6, §9).
+- Canned responses for the handful of subresource requests SDKs probe on startup (see §10).
+- Health/metrics endpoints and `CANDYBOX_*` config parity with the node (see §11, §12).
+
+### Out of scope (v1) — see §16 for the deferred-feature plan
+
+- **Multipart upload** (`CreateMultipartUpload`/`UploadPart`/`Complete`/`Abort`) — requires native
+  multipart support in Candybox; deferred.
+- **Real MD5 ETag + `Content-MD5`/checksum verification** — requires a new object-metadata layer to
+  persist the MD5 alongside the object; deferred.
+- **Range GET (HTTP 206)** — requires an engine-level byte-window read; deferred (v1 returns the full
+  object with HTTP 200 and ignores the `Range` header).
+- **TLS** — terminated at the external HTTP(S) load balancer, which is **out of scope**. The gateway
+  listens on plain HTTP behind the LB.
+- Authentication/authorization (SigV4), bucket policies, ACLs, CORS config, lifecycle, object
+  tagging, versioning, storage classes, multi-region.
+
+### Assumptions
+
+- An external HTTP(S) **load balancer** terminates TLS and fan-outs requests across gateway instances.
+  Gateways are interchangeable and hold no per-request state, so the LB may use any policy (round
+  robin is fine). The LB, its DNS, and its certificate are **not** part of this work.
+- The gateway reaches the cluster in **cluster-routing mode** (`CandyboxClient` constructed with a
+  `CoordinationService`), so it resolves each Box's fenced owner via ZooKeeper and follows `MOVED`
+  exactly like the CLI does in a cluster.
+
+---
+
+## 2. Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| HTTP server | **Netty** | Async I/O, streaming bodies, backpressure; avoids buffering whole objects. |
+| TLS | At the **load balancer** (out of scope) | Gateway stays plain-HTTP and simple; LB owns certs. |
+| Auth | **Anonymous** (ignore `Authorization`) | Trusted-network deployment; SigV4 deferred. |
+| Addressing | **Path-style only** | One hostname/cert at the LB; no wildcard DNS. |
+| ETag | **Deterministic from CRC32C** | Stable across PUT/GET/HEAD, zero extra storage; real MD5 deferred. |
+| Range GET | **Deferred** (full object, HTTP 200) | Needs engine byte-window read; not available yet. |
+| Multipart | **Deferred** | Needs native multipart in Candybox. |
+| Object size | Single-shot PUT bounded by configured max (see §11) | No multipart, so very large single PUTs are bounded. |
+
+---
+
+## 3. Module & dependencies
+
+New Maven module **`candybox-s3-gateway`**, added to the root `pom.xml` `<modules>` list (after
+`candybox-client`).
+
+**Depends on:**
+- `candybox-client` — the `CandyboxClient` API and its `CandyInfo` / `Listing` records.
+- `candybox-common` — `BoxName`, `CandyKey`, `CandyboxConfig`, exception types, CRC32C helper.
+- `candybox-coordination` — `CoordinationService` for cluster routing (same as the CLI's cluster mode).
+- `candybox-protocol` — `TcpTransport` (transitively via the client).
+- **Netty** (`io.netty:netty-all` or the codec-http + transport artifacts) — new third-party dep.
+  Pin the version in the root `pom.xml` `<properties>` (`netty.version`) like the other deps.
+
+**Must NOT depend on** `candybox-lsm`, `candybox-bookkeeper`, or the raw BookKeeper/ZooKeeper clients
+— the gateway is a *client* of the cluster, not a storage node. This respects the module dependency
+rule in `CLAUDE.md`.
+
+Suggested package: `me.predatorray.candybox.s3`.
+
+```
+candybox-s3-gateway/
+  src/main/java/me/predatorray/candybox/s3/
+    S3GatewayMain.java          # entrypoint: load config, build CandyboxClient, start Netty
+    S3GatewayConfig.java        # CANDYBOX_*/properties config (mirrors ServerConfig style)
+    S3GatewayServer.java        # Netty bootstrap, channel pipeline, graceful shutdown
+    http/
+      S3RequestRouter.java      # parse method+path+query -> S3Operation
+      S3Operation.java          # enum/sealed: PutObject, GetObject, ListObjectsV2, ...
+      S3RequestHandler.java     # Netty inbound handler; dispatches to ops on a worker pool
+      BlockingBridge.java       # Netty <-> InputStream/OutputStream bridges (see §4)
+    op/                         # one class per operation, each calls CandyboxClient
+      BucketOps.java            # create/delete/head/list buckets
+      ObjectOps.java            # put/get/head/delete/copy
+      ListObjectsOp.java        # listing + delimiter rollup + pagination
+      DeleteObjectsOp.java      # batch delete
+      CannedSubresourceOps.java # ?location, ?versioning, ?acl probes (§10)
+    xml/
+      S3XmlWriter.java          # streaming XML for list results, copy result, errors
+      S3Error.java              # error code catalog + HTTP status
+    ErrorMapper.java            # CandyboxException -> S3Error (§9)
+    Etag.java                   # crc32c -> ETag string (§8)
+  src/test/java/...             # unit tests (fakes / in-JVM)
+```
+
+Integration tests live in **`candybox-integration-tests`** (the `*IT` convention), not in this module
+— see §13.
+
+---
+
+## 4. Architecture & request flow
+
+### Threading model (the important part)
+
+`CandyboxClient`/`TcpTransport` are **blocking**. Netty's event-loop threads must never block. So the
+gateway uses the standard Netty pattern: the event loop handles HTTP framing and backpressure, and all
+`CandyboxClient` calls run on a **dedicated blocking worker pool** (`DefaultEventExecutorGroup` or a
+plain `ExecutorService` handed the request). Bridges connect the two worlds:
+
+- **PutObject (request body → Candybox):** Netty delivers `HttpContent` chunks on the event loop. They
+  are fed into a bounded blocking buffer that the worker thread reads as an `InputStream`, passed
+  straight to `client.putCandy(box, key, inputStream, contentType, userMetadata)`. Backpressure: when
+  the buffer is full, toggle channel auto-read off so the client/LB slows down. (`BlockingBridge`.)
+- **GetObject (Candybox → response body):** the worker thread calls
+  `client.getCandy(box, key, outputStream)` where `outputStream` writes into Netty, respecting
+  `Channel.isWritable()` (flush + wait when the outbound buffer fills). This streams large objects
+  without buffering them in memory.
+
+> v1 interim simplification (optional): because multipart is deferred and single PUTs are size-bounded
+> (§11), an initial cut MAY use `HttpObjectAggregator` with `maxContentLength = maxObjectSize` to buffer
+> the request body in memory and skip the PUT bridge. This is simpler but caps memory per concurrent
+> upload. The streaming bridge above is the target design and the reason we chose Netty; prefer it for
+> GET from day one (read objects can be large) and adopt it for PUT as soon as the bridge lands.
+
+### Netty pipeline
+
+```
+SocketChannel
+  └─ HttpServerCodec               (request line/headers/response encoding)
+  └─ HttpContentDecompressor       (handle Content-Encoding: gzip if a client sends it)
+  └─ ChunkedWriteHandler           (stream large GET responses)
+  └─ S3RequestHandler              (route + dispatch to worker pool; NO blocking here)
+```
+
+Note: do **not** put a giant `HttpObjectAggregator` in the streaming design. Handle the
+`aws-chunked` transfer encoding explicitly (see §10) — strip chunk framing before writing object
+bytes to Candybox.
+
+### Request lifecycle
+
+1. Event loop parses request line + headers → `S3RequestRouter` produces an `S3Operation` from
+   `(method, path, query, headers)`.
+2. Handler submits the op to the worker pool with a handle to the channel and (for PUT) the body bridge.
+3. Worker calls the matching `CandyboxClient` method, maps the result/exception, and writes the HTTP
+   response (status + S3 headers + XML/stream body) back through the channel.
+4. On `CandyboxException`, `ErrorMapper` produces the S3 status + XML error body (§9).
+
+---
+
+## 5. Routing & addressing (path-style)
+
+URL shape: `/<bucket>/<key...>` (key may contain slashes). `Host` header is ignored for bucket
+resolution.
+
+| Path | Method | Operation |
+|---|---|---|
+| `/` | `GET` | `ListBuckets` |
+| `/<bucket>` (or `/<bucket>/`) | `PUT` | `CreateBucket` |
+| `/<bucket>` | `DELETE` | `DeleteBucket` |
+| `/<bucket>` | `HEAD` | `HeadBucket` |
+| `/<bucket>` | `GET` | `ListObjectsV2` (or V1 if `list-type` absent) |
+| `/<bucket>?delete` | `POST` | `DeleteObjects` (batch) |
+| `/<bucket>?location` `?versioning` `?acl` … | `GET` | canned subresource (§10) |
+| `/<bucket>/<key>` | `PUT` | `PutObject`, or `CopyObject` if `x-amz-copy-source` header present |
+| `/<bucket>/<key>` | `GET` | `GetObject` (full object; `Range` ignored in v1) |
+| `/<bucket>/<key>` | `HEAD` | `HeadObject` |
+| `/<bucket>/<key>` | `DELETE` | `DeleteObject` |
+
+**Key handling:** URL-decode the key path segment(s). Preserve slashes within the key. Validate via
+`CandyKey` (non-empty UTF-8, ≤ configured max bytes) and `BoxName` (already enforces S3 bucket rules:
+3–63 chars, `[a-z0-9-]`). Validation failures → `400 InvalidBucketName` / `InvalidArgument`.
+
+---
+
+## 6. API surface — mapping to `CandyboxClient`
+
+| S3 operation | CandyboxClient call | Response notes |
+|---|---|---|
+| `CreateBucket` | `createBox(bucket)` | `200`, `Location: /<bucket>` header. |
+| `DeleteBucket` | `deleteBox(bucket, force=false)` | `204`. `BucketNotEmpty` → 409 (§9). |
+| `HeadBucket` | `headBox(bucket)` | `200` if present, `404` otherwise (no body on HEAD). |
+| `ListBuckets` | `listBoxes()` | `200`, `ListAllMyBucketsResult` XML; synthesize a `CreationDate` (epoch/now — Candybox has no bucket-create timestamp). |
+| `PutObject` | `putCandy(box, key, InputStream, contentType, userMetadata)` | `200`, `ETag` header (§8). Map `Content-Type` and `x-amz-meta-*` → `userMetadata`. |
+| `CopyObject` | `copyCandy(box, srcKey, dstKey, idempotencyToken)` | Same-bucket only (Candybox `copyCandy` is intra-Box). `x-amz-copy-source` parsed; cross-bucket copy → `501`/`NotImplemented` in v1. Response: `CopyObjectResult` XML with `ETag`. |
+| `GetObject` | `getCandy(box, key, OutputStream)` | `200`, stream body; headers: `Content-Length`, `Content-Type`, `ETag`, `Last-Modified` (from `createdAtMillis`), `x-amz-meta-*`. |
+| `HeadObject` | `headCandy(box, key)` → `CandyInfo` | Same headers as GET, no body. |
+| `DeleteObject` | `deleteCandy(box, key)` | `204` (idempotent: deleting a missing key still returns `204`, per S3). |
+| `DeleteObjects` | loop `deleteCandy` per key (optionally `deleteRange` for prefix-shaped requests) | `200`, `DeleteResult` XML listing `Deleted`/`Error` per key. |
+| `ListObjectsV2` | `listCandies(prefix, startAfter, maxKeys)` | See §7. |
+
+`CandyInfo` fields available: `contentLength`, `contentType`, `userMetadata`, `crc32c`,
+`createdAtMillis`. `Listing.Entry`: `key`, `contentLength`, `createdAtMillis`.
+
+---
+
+## 7. Listing semantics
+
+Map S3 `ListObjectsV2` params onto `listCandies(prefix, startAfter, maxKeys)`:
+
+- `prefix` → `prefix`.
+- `continuation-token` (V2) / `marker` (V1) / `start-after` → `startAfter`. Use the opaque
+  `Listing.nextStartAfter` as the `continuation-token` we return; no need to base64 unless we want to
+  hide the key (recommended: base64-encode it so it reads as opaque to clients).
+- `max-keys` → `maxKeys` (clamp to 1000 default like S3).
+- `Listing.isTruncated()` / `nextStartAfter` → `<IsTruncated>` + `<NextContinuationToken>`.
+
+**`delimiter` (CommonPrefixes) is synthesized in the gateway:** when a delimiter is supplied, after
+fetching a page, group keys by their first delimiter occurrence *after the prefix*; collapse each group
+into a `<CommonPrefixes><Prefix>` entry and suppress the individual keys. Because rollup happens
+post-fetch, a page may yield fewer than `max-keys` `Contents` entries — that is S3-legal. (A future
+engine-level delimiter scan would make this cheaper; see §16.)
+
+XML: `ListBucketResult` with `Name`, `Prefix`, `Delimiter`, `MaxKeys`, `KeyCount`, `IsTruncated`,
+`Contents[]` (`Key`, `LastModified` from `createdAtMillis`, `ETag` from crc32c, `Size`,
+`StorageClass=STANDARD`), `CommonPrefixes[]`.
+
+---
+
+## 8. ETag strategy (deterministic from CRC32C)
+
+S3 clients expect an `ETag` header on PUT/GET/HEAD and within list entries. v1 derives it from the
+CRC32C that Candybox already stores in `CandyMetadata`/`CandyInfo`:
+
+```
+ETag = quote( leftPad( hex(crc32c & 0xffffffffL), 32, '0') )
+e.g. crc32c=0x8f3a2b1c  ->  ETag: "000000008f3a2b1c"
+```
+
+Properties: deterministic and stable across PUT/GET/HEAD/List for the same bytes; needs no extra
+storage. **Caveat:** it is *not* the MD5 S3 normally returns, so a client that independently computes
+MD5 and strictly compares may warn or reject. This is an accepted v1 limitation; real MD5 ETags are a
+deferred feature (§16) because they need a new metadata layer to persist the digest.
+
+`Etag.java` centralizes the formatting so the future swap to real MD5 touches one place.
+
+---
+
+## 9. Error model
+
+Every error is an HTTP status + an S3 `<Error>` XML body:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchKey</Code>
+  <Message>The specified key does not exist.</Message>
+  <Resource>/photos/cat.jpg</Resource>
+  <RequestId>...</RequestId>
+</Error>
+```
+
+`ErrorMapper` translates Candybox exceptions (all from `candybox-common`/client) to S3 codes:
+
+| Candybox exception | HTTP | S3 `<Code>` |
+|---|---|---|
+| `CandyNotFoundException` | 404 | `NoSuchKey` |
+| `BoxNotFoundException` | 404 | `NoSuchBucket` |
+| `BoxAlreadyExistsException` | 409 | `BucketAlreadyOwnedByYou` |
+| `BoxNotEmptyException` | 409 | `BucketNotEmpty` |
+| `ValidationException` (bad bucket name) | 400 | `InvalidBucketName` |
+| `ValidationException` (other) | 400 | `InvalidArgument` |
+| `LimitExceededException` (key too long) | 400 | `KeyTooLongError` |
+| `LimitExceededException` (object too large) | 400 | `EntityTooLarge` |
+| `BusyException` | 503 | `SlowDown` |
+| `NotOwnerException` / `FencedException` | 503 | `ServiceUnavailable` (retryable; ownership in flux) |
+| `StorageException` / `SerializationException` | 500 | `InternalError` |
+| anything unmapped | 500 | `InternalError` |
+
+Notes:
+- `DeleteObject` on a missing key is **not** an error in S3 — return `204` regardless.
+- On `503` responses, set a `Retry-After` header so well-behaved clients back off; the LB and SDK retry
+  logic will then re-drive to a (possibly new) owner.
+- Generate a per-request `RequestId` (UUID) and echo it in `x-amz-request-id` and error bodies for
+  debuggability.
+
+---
+
+## 10. Anonymous mode & SDK-compatibility shims
+
+Even with no auth, real SDKs/CLIs behave as if talking to AWS, so the gateway must tolerate their
+quirks:
+
+- **`Authorization` / `x-amz-content-sha256` headers:** accept and **ignore**. Do not 400 on their
+  presence; do not verify.
+- **`aws-chunked` transfer encoding:** boto3/aws-cli may send `Content-Encoding: aws-chunked` with
+  `x-amz-decoded-content-length` even unsigned. The gateway **must de-chunk** the body (strip the
+  per-chunk size/signature framing) before writing object bytes — otherwise stored objects are
+  corrupted. Use `x-amz-decoded-content-length` as the true `Content-Length` for the `putCandy` call.
+- **`Expect: 100-continue`:** honor it (Netty can) so large PUTs don't send the body before headers
+  are accepted.
+- **Startup subresource probes:** return benign canned XML so clients don't choke —
+  `GET /<bucket>?location` → `<LocationConstraint>` (empty / configured region),
+  `GET /<bucket>?versioning` → empty `<VersioningConfiguration>`, `?acl` → a canned private ACL,
+  `?cors`/`?lifecycle`/`?tagging` → `404 NoSuch*Configuration`. Keep this list in
+  `CannedSubresourceOps`.
+- **Client guidance (docs):** since multipart is deferred, large uploads from default SDK config will
+  try multipart and fail — document raising `s3.multipart_threshold` (boto3) or
+  `multipart_threshold` (aws-cli) above the max object size, and using `--endpoint-url` with
+  path-style addressing (`addressing_style = path`).
+
+---
+
+## 11. Configuration
+
+Follow the node's `ServerConfig` pattern exactly: `conf/*.properties` keys overridable by
+`CANDYBOX_<KEY>` env vars (dots → underscores, upper-cased), env wins.
+
+| Key | Meaning | Default |
+|---|---|---|
+| `s3.bind` | Address the gateway listens on (plain HTTP, behind the LB). | `0.0.0.0:9711` |
+| `zookeeper.connect` | ZooKeeper connect string for cluster routing (shared with the cluster). | `127.0.0.1:2181` |
+| `s3.region` | Value returned in `?location` and any region echoes. | `us-east-1` |
+| `s3.max-object-bytes` | Reject single PUTs larger than this (no multipart). | from `SizeLimits` / e.g. 5 GiB |
+| `s3.worker-threads` | Size of the blocking worker pool calling `CandyboxClient`. | `2 × cores` |
+| `s3.router-cache-ttl-ms` | Box→owner resolution cache TTL (passed to the cluster router). | client default |
+| `health.port` | HTTP port for `/healthz`, `/readyz`, `/metrics`. | `9712` |
+
+The gateway builds `CandyboxClient(transport, coordinationService, candyboxConfig)` (cluster mode), so
+it needs `zookeeper.connect` rather than a single `host:port`.
+
+---
+
+## 12. Health, metrics, operations
+
+- Reuse the node's health-server shape: `/healthz` (liveness — process up), `/readyz` (readiness —
+  ZooKeeper reachable + at least one route resolvable), `/metrics`. Run it on `health.port`,
+  separate from the S3 listener, so the LB can health-check independently.
+- Metrics to expose: request count/latency per operation, error counts by S3 code, in-flight uploads,
+  bytes in/out, worker-pool saturation, `MOVED` re-routes.
+- **Graceful shutdown:** stop accepting new connections, drain in-flight requests (bounded), then close
+  Netty groups and the `CandyboxClient`. The LB removes the instance on `/readyz` failure.
+- Packaging: add a gateway launcher to `candybox-dist` (`bin/candybox-s3-gateway`) and a third mode to
+  the Docker image (alongside node + CLI), plus a Compose service and a K8s `Deployment` (stateless —
+  not a `StatefulSet`) under `examples/`.
+
+---
+
+## 13. Testing strategy
+
+Mirror the repo's split (unit fakes vs `*IT` on real backends; no mocking frameworks):
+
+**Unit tests (`candybox-s3-gateway/src/test`, `mvn test`):**
+- `S3RequestRouter` path/query → operation mapping (incl. `?delete`, subresources, copy-source header).
+- `ErrorMapper` exhaustive exception → status/code table (§9).
+- `Etag` formatting.
+- `S3XmlWriter` golden-XML tests for `ListBucketResult`, `ListAllMyBucketsResult`, `DeleteResult`,
+  `CopyObjectResult`, `Error`.
+- Listing delimiter rollup / `CommonPrefixes` logic over a fake `Listing`.
+- `aws-chunked` de-chunking unit test (framed input → raw bytes).
+- HTTP handler tests using Netty's `EmbeddedChannel` (no sockets) against a hand-written fake
+  `CandyboxClient` seam (extract a small interface the handler depends on, fake it in tests —
+  consistent with the SPI+fake pattern).
+
+**Integration tests (`candybox-integration-tests`, `*IT`, `mvn verify`):**
+- `S3GatewayIT`: boot embedded BookKeeper + in-JVM ZooKeeper + a real Candybox node + the gateway, then
+  drive it with an **HTTP client** (and ideally the **AWS SDK for Java v2** pointed at the gateway with
+  path-style + anonymous credentials) through create-bucket → put → head → get → list (with delimiter
+  + pagination) → copy → delete → delete-bucket. Assert bytes round-trip and ETag is stable.
+- A negative-path `*IT` covering the error mappings end-to-end (missing key/bucket, non-empty bucket).
+- Respect the existing IT conventions: `*IT` suffix, failsafe binding, `reuseForks=false`, and the
+  `--add-opens` `argLine`.
+
+---
+
+## 14. Milestones / effort ordering
+
+1. **Skeleton:** module + Netty bootstrap + config + health server + `CandyboxClient` (cluster mode)
+   wiring + graceful shutdown.
+2. **Error/XML framework:** `S3Error`, `ErrorMapper`, `S3XmlWriter`, `RequestId`.
+3. **Bucket ops:** create/delete/head/list + their XML and error mappings. First end-to-end `*IT`.
+4. **Object ops (single-shot):** PutObject (streaming bridge + aws-chunked de-chunk), GetObject
+   (streaming), HeadObject, DeleteObject + ETag from crc32c.
+5. **Listing:** ListObjectsV2/V1, pagination, delimiter/CommonPrefixes rollup.
+6. **CopyObject + DeleteObjects (batch).**
+7. **SDK shims:** canned subresources, `Expect: 100-continue`, ignore-auth, docs for client config.
+8. **Packaging:** dist launcher, Docker third mode, Compose + K8s `Deployment` examples.
+
+---
+
+## 15. Remaining minor decisions (sensible defaults chosen; flag to revisit)
+
+- **Bucket `CreationDate`:** Candybox stores none. Default: return process-start/epoch placeholder.
+  (A real value needs a bucket-metadata field — minor future work.)
+- **`DeleteObjects` strategy:** default to a per-key `deleteCandy` loop; optionally detect a pure-prefix
+  batch and use `deleteRange` as an optimization later.
+- **`max-keys` clamp:** default cap 1000 (S3 parity).
+- **Continuation token opacity:** base64-encode `nextStartAfter` so clients treat it as opaque.
+- **Cross-bucket `CopyObject`:** v1 returns `501 NotImplemented` (Candybox `copyCandy` is intra-Box);
+  revisit if needed.
+
+---
+
+## 16. Deferred features (future plans)
+
+These were intentionally deferred from v1 because each requires **new Candybox capabilities**, not just
+gateway code:
+
+1. **Multipart upload.** Requires *native multipart support in Candybox* — a way to stage parts and
+   atomically assemble them into one object (ideally reusing Syrup/zero-copy mechanics) plus an
+   upload-id/parts registry. Until then, the gateway cannot faithfully implement
+   `CreateMultipartUpload`/`UploadPart`/`CompleteMultipartUpload`/`AbortMultipartUpload`, and large
+   uploads must use single-shot PUT under `s3.max-object-bytes`. When this lands, the gateway gains the
+   four MPU operations and the composite `-N` ETag form.
+
+2. **Real MD5 ETag + checksum verification.** Requires a *new object-metadata layer* to compute and
+   persist the MD5 digest (and optionally validate `Content-MD5` / `x-amz-checksum-*` on PUT).
+   Candybox currently stores only CRC32C, hence the deterministic-from-CRC32C interim ETag (§8). When
+   the metadata layer exists, `Etag.java` swaps to the stored MD5 and the gateway can enforce
+   `Content-MD5` and the SDK checksum headers. (MPU's composite ETag depends on this too.)
+
+3. **Range GET (HTTP 206).** Requires an *engine/protocol byte-window read* so the gateway can fetch
+   `[offset, offset+len)` directly from the Syrup instead of streaming-and-discarding. Until then v1
+   ignores `Range` and returns the full object (HTTP 200). When the engine read lands, add 206 +
+   `Content-Range` + multi-range support.
+
+4. **Other S3 surface (further out):** virtual-host addressing (needs wildcard DNS/cert at the LB),
+   SigV4 authentication + a credential store, object versioning (the LSM tree is LWW today),
+   bucket policies/ACLs/CORS/lifecycle/tagging, and an engine-level delimiter scan to make
+   `CommonPrefixes` cheap.
+```

--- a/candybox-dist/pom.xml
+++ b/candybox-dist/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>candybox-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- The S3 gateway and its Netty runtime, so lib/ can launch it via bin/candybox-s3-gateway. -->
+        <dependency>
+            <groupId>me.predatorray.candybox</groupId>
+            <artifactId>candybox-s3-gateway</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- The single production SLF4J binding (tests elsewhere use slf4j-simple). -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/candybox-dist/src/bin/candybox-s3-gateway
+++ b/candybox-dist/src/bin/candybox-s3-gateway
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Starts the Candybox S3 gateway in the FOREGROUND (logs to stdout, no daemonization) so a process
+# supervisor or container orchestrator owns its lifecycle. SIGTERM/Ctrl-C triggers a graceful
+# shutdown. The gateway is stateless and is meant to sit behind an HTTP(S) load balancer.
+#
+# Usage: candybox-s3-gateway [path/to/candybox-s3-gateway.properties]
+#   Defaults to $CANDYBOX_CONF_DIR/candybox-s3-gateway.properties.
+#
+# Set CANDYBOX_DRY_RUN=1 to print the resolved java command instead of executing it.
+#
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=candybox-env.sh
+source "$BIN_DIR/candybox-env.sh"
+
+CONFIG_FILE="${1:-$CANDYBOX_CONF_DIR/candybox-s3-gateway.properties}"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "ERROR: configuration file not found: $CONFIG_FILE" >&2
+  echo "Copy $CANDYBOX_CONF_DIR/candybox-s3-gateway.properties.example to" >&2
+  echo "candybox-s3-gateway.properties and edit it, or pass a config path as the first argument." >&2
+  exit 1
+fi
+
+mkdir -p "$CANDYBOX_LOG_DIR"
+
+CMD=("$JAVA" "${CANDYBOX_JVM_OPTS[@]}" -cp "$CLASSPATH"
+     me.predatorray.candybox.s3.S3GatewayMain "$CONFIG_FILE")
+
+if [[ -n "${CANDYBOX_DRY_RUN:-}" ]]; then
+  printf '%s ' "${CMD[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${CMD[@]}"

--- a/candybox-dist/src/conf/candybox-s3-gateway.properties.example
+++ b/candybox-dist/src/conf/candybox-s3-gateway.properties.example
@@ -1,0 +1,30 @@
+# Candybox S3 gateway configuration (example).
+#
+# The gateway is an anonymous, path-style, S3-compatible HTTP front-end that translates S3 requests
+# onto the Candybox cluster. It is stateless and is intended to run behind an HTTP(S) load balancer
+# (which terminates TLS); the gateway itself listens on plain HTTP.
+#
+# Every key below can be overridden by an environment variable named CANDYBOX_<KEY> (dots and dashes
+# become underscores, upper-cased); the environment value wins. e.g. CANDYBOX_S3_BIND, CANDYBOX_ZOOKEEPER_CONNECT.
+
+# Address the S3 HTTP listener binds to (plain HTTP, behind the load balancer).
+s3.bind=0.0.0.0:9711
+
+# ZooKeeper connect string of the Candybox cluster (used for owner routing). REQUIRED.
+zookeeper.connect=127.0.0.1:2181
+
+# Region echoed in ?location and related responses.
+s3.region=us-east-1
+
+# Reject single PUTs larger than this many bytes (no multipart upload in v1). Note: the practical
+# ceiling is ~2 GiB because the request is buffered in full. Default: 5368709120 (5 GiB, capped to ~2 GiB).
+# s3.max-object-bytes=5368709120
+
+# Size of the blocking worker pool that issues Candybox client calls. Default: 2 x CPU cores (min 4).
+# s3.worker-threads=8
+
+# Box->owner resolution cache TTL (ms). Default: 5000.
+# s3.router-cache-ttl-ms=5000
+
+# HTTP port for /healthz, /readyz, /metrics. Default: 9712.
+# health.port=9712

--- a/candybox-integration-tests/pom.xml
+++ b/candybox-integration-tests/pom.xml
@@ -45,6 +45,12 @@
             <groupId>me.predatorray.candybox</groupId>
             <artifactId>candybox-client</artifactId>
         </dependency>
+        <!-- The S3 gateway, exercised end-to-end over a real node (pulls Netty transitively). -->
+        <dependency>
+            <groupId>me.predatorray.candybox</groupId>
+            <artifactId>candybox-s3-gateway</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Reuse the shared contract suites against the real BookKeeper / ZooKeeper backends. -->
         <dependency>

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/S3GatewayIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/S3GatewayIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import me.predatorray.candybox.bookkeeper.bk.BookKeeperLedgerStore;
+import me.predatorray.candybox.client.CandyboxClient;
+import me.predatorray.candybox.common.SystemClock;
+import me.predatorray.candybox.common.config.CandyboxConfig;
+import me.predatorray.candybox.coordination.zk.ZooKeeperCoordinationService;
+import me.predatorray.candybox.protocol.FrameCodec;
+import me.predatorray.candybox.protocol.transport.TcpTransport;
+import me.predatorray.candybox.protocol.transport.TcpTransportServer;
+import me.predatorray.candybox.s3.S3Gateway;
+import me.predatorray.candybox.s3.S3GatewayConfig;
+import me.predatorray.candybox.server.CandyboxNode;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test of the S3 gateway over the full stack: embedded BookKeeper, in-process ZooKeeper, a
+ * real Candybox node, and the Netty gateway, driven with the JDK HTTP client (anonymous, path-style —
+ * exactly how a load balancer would forward). Exercises the bucket/object lifecycle and the
+ * deterministic CRC32C ETag round-trip. See {@code S3_GATEWAY_PLAN.md} §13.
+ */
+class S3GatewayIT {
+
+    private static EmbeddedBookKeeper bookKeeper;
+    private static TestingServer zookeeper;
+
+    private static CandyboxNode node;
+    private static TcpTransportServer transportServer;
+    private static TcpTransport transport;
+    private static ZooKeeperCoordinationService nodeCoord;
+    private static ZooKeeperCoordinationService clientCoord;
+    private static BookKeeperLedgerStore store;
+    private static CandyboxClient client;
+    private static S3Gateway gateway;
+
+    private static HttpClient http;
+    private static String baseUri;
+
+    @BeforeAll
+    static void start() throws Exception {
+        bookKeeper = new EmbeddedBookKeeper(3);
+        zookeeper = new TestingServer(true);
+
+        CandyboxConfig config = CandyboxConfig.builder().build();
+        int nodePort = freePort();
+        store = new BookKeeperLedgerStore(bookKeeper.clientConfiguration(), "candybox".getBytes(StandardCharsets.UTF_8));
+        nodeCoord = new ZooKeeperCoordinationService(zookeeper.getConnectString(), SystemClock.INSTANCE);
+        node = new CandyboxNode(1, config, store, nodeCoord, SystemClock.INSTANCE, "127.0.0.1:" + nodePort);
+        transportServer = new TcpTransportServer(nodePort, node.requestHandler(), new FrameCodec());
+
+        transport = new TcpTransport();
+        clientCoord = new ZooKeeperCoordinationService(zookeeper.getConnectString(), SystemClock.INSTANCE);
+        client = new CandyboxClient(transport, clientCoord, config);
+
+        Properties props = new Properties();
+        props.setProperty("zookeeper.connect", zookeeper.getConnectString());
+        props.setProperty("s3.bind", "127.0.0.1:0");
+        gateway = new S3Gateway(S3GatewayConfig.fromProperties(props, java.util.Map.of()), client);
+        gateway.start();
+
+        // The gateway speaks HTTP/1.1 only; pin the client so it doesn't attempt an h2c upgrade.
+        http = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        baseUri = "http://127.0.0.1:" + gateway.port();
+    }
+
+    @AfterAll
+    static void stop() throws Exception {
+        closeQuietly(gateway);
+        closeQuietly(client);
+        closeQuietly(transport);
+        closeQuietly(transportServer);
+        closeQuietly(node);
+        closeQuietly(nodeCoord);
+        closeQuietly(clientCoord);
+        closeQuietly(store);
+        if (zookeeper != null) {
+            zookeeper.close();
+        }
+        if (bookKeeper != null) {
+            bookKeeper.close();
+        }
+    }
+
+    @Test
+    void fullBucketAndObjectLifecycle() throws Exception {
+        // Create bucket.
+        assertThat(send("PUT", "/photos", null).statusCode()).isEqualTo(200);
+
+        // Put an object.
+        byte[] data = "hello candybox".getBytes(StandardCharsets.UTF_8);
+        HttpResponse<String> put = send("PUT", "/photos/hello.txt", data, "Content-Type", "text/plain");
+        assertThat(put.statusCode()).isEqualTo(200);
+        String etag = put.headers().firstValue("ETag").orElseThrow();
+        assertThat(etag).hasSize(34); // 32 hex chars + surrounding quotes
+
+        // Get it back, bytes and ETag must match.
+        HttpResponse<byte[]> get = http.send(
+                HttpRequest.newBuilder(URI.create(baseUri + "/photos/hello.txt")).GET().build(),
+                BodyHandlers.ofByteArray());
+        assertThat(get.statusCode()).isEqualTo(200);
+        assertThat(get.body()).isEqualTo(data);
+        assertThat(get.headers().firstValue("ETag")).hasValue(etag);
+        assertThat(get.headers().firstValue("Content-Type")).hasValue("text/plain");
+
+        // Head.
+        HttpResponse<String> head = send("HEAD", "/photos/hello.txt", null);
+        assertThat(head.statusCode()).isEqualTo(200);
+        assertThat(head.headers().firstValue("Content-Length")).hasValue(Integer.toString(data.length));
+
+        // List (ListObjectsV2).
+        HttpResponse<String> list = send("GET", "/photos?list-type=2", null);
+        assertThat(list.statusCode()).isEqualTo(200);
+        assertThat(list.body()).contains("<Key>hello.txt</Key>").contains("<IsTruncated>false</IsTruncated>");
+
+        // Server-side copy within the bucket.
+        HttpResponse<String> copy = send("PUT", "/photos/copy.txt", new byte[0],
+                "x-amz-copy-source", "/photos/hello.txt");
+        assertThat(copy.statusCode()).isEqualTo(200);
+        assertThat(copy.body()).contains("<CopyObjectResult>");
+        HttpResponse<byte[]> getCopy = http.send(
+                HttpRequest.newBuilder(URI.create(baseUri + "/photos/copy.txt")).GET().build(),
+                BodyHandlers.ofByteArray());
+        assertThat(getCopy.body()).isEqualTo(data);
+
+        // Delete objects, then the (now empty) bucket.
+        assertThat(send("DELETE", "/photos/hello.txt", null).statusCode()).isEqualTo(204);
+        assertThat(send("DELETE", "/photos/copy.txt", null).statusCode()).isEqualTo(204);
+        assertThat(send("DELETE", "/photos", null).statusCode()).isEqualTo(204);
+    }
+
+    @Test
+    void getMissingKeyReturnsNoSuchKey() throws Exception {
+        send("PUT", "/inbox", null);
+        HttpResponse<String> get = send("GET", "/inbox/nope.txt", null);
+        assertThat(get.statusCode()).isEqualTo(404);
+        assertThat(get.body()).contains("<Code>NoSuchKey</Code>");
+    }
+
+    @Test
+    void deleteObjectIsIdempotent() throws Exception {
+        send("PUT", "/trash", null);
+        assertThat(send("DELETE", "/trash/never-existed.txt", null).statusCode()).isEqualTo(204);
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------
+
+    private HttpResponse<String> send(String method, String path, byte[] body, String... headers)
+            throws Exception {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(baseUri + path));
+        b.method(method, body == null ? BodyPublishers.noBody() : BodyPublishers.ofByteArray(body));
+        for (int i = 0; i + 1 < headers.length; i += 2) {
+            b.header(headers[i], headers[i + 1]);
+        }
+        return http.send(b.build(), BodyHandlers.ofString());
+    }
+
+    private static int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) {
+            return;
+        }
+        try {
+            c.close();
+        } catch (Exception ignored) {
+            // best effort
+        }
+    }
+}

--- a/candybox-s3-gateway/pom.xml
+++ b/candybox-s3-gateway/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>me.predatorray.candybox</groupId>
+        <artifactId>candybox-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>candybox-s3-gateway</artifactId>
+    <name>Candybox :: S3 Gateway</name>
+    <description>An anonymous, path-style S3-compatible HTTP gateway (Netty) that translates the S3
+        REST/XML protocol onto the Candybox client API. Stateless; sits behind an HTTP(S) load
+        balancer. See S3_GATEWAY_PLAN.md.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>me.predatorray.candybox</groupId>
+            <artifactId>candybox-common</artifactId>
+        </dependency>
+        <!-- The gateway is a *client* of the cluster, never a storage node: it depends on the thin
+             client (and, transitively, protocol) plus the coordination SPI for cluster routing. It must
+             NOT depend on candybox-lsm/candybox-bookkeeper or the raw BK/ZK clients. -->
+        <dependency>
+            <groupId>me.predatorray.candybox</groupId>
+            <artifactId>candybox-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>me.predatorray.candybox</groupId>
+            <artifactId>candybox-coordination</artifactId>
+        </dependency>
+
+        <!-- Netty HTTP server (pulls transport/buffer/common/codec/handler transitively). -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+
+        <!-- Runtime backend for this composition root: candybox-coordination marks curator `optional`
+             so it stays off other modules' classpaths; the gateway, like the server, provides it here.
+             Gateway CODE references only the SPI impl (ZooKeeperCoordinationService), never raw curator. -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/AwsChunked.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/AwsChunked.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Strips the AWS {@code aws-chunked} content-encoding framing from a request body, recovering the raw
+ * object bytes.
+ *
+ * <p>Even with no signature verification, the AWS SDKs/CLI may upload with
+ * {@code Content-Encoding: aws-chunked} (signalled by an {@code x-amz-content-sha256} of
+ * {@code STREAMING-*}). The wire body is then a sequence of chunks:
+ *
+ * <pre>
+ *   &lt;hex-size&gt;[;chunk-signature=...]\r\n &lt;size bytes&gt; \r\n
+ *   ...
+ *   0[;chunk-signature=...]\r\n [trailers] \r\n
+ * </pre>
+ *
+ * <p>If we stored the framing verbatim the object would be corrupted, so this decoder must run before
+ * the bytes reach {@code putCandy}. The chunk signatures and trailers are ignored (we don't verify).
+ * See {@code S3_GATEWAY_PLAN.md} §10.
+ */
+final class AwsChunked {
+
+    private AwsChunked() {
+    }
+
+    /** Whether a request body is {@code aws-chunked} framed, from its headers. */
+    static boolean isChunked(String contentEncoding, String contentSha256) {
+        if (contentEncoding != null && contentEncoding.toLowerCase().contains("aws-chunked")) {
+            return true;
+        }
+        return contentSha256 != null && contentSha256.startsWith("STREAMING-");
+    }
+
+    /** Decodes the framed body into the raw payload. {@code expectedLength} (&lt;0 if unknown) sizes the buffer. */
+    static byte[] decode(byte[] framed, long expectedLength) {
+        ByteArrayOutputStream out =
+                new ByteArrayOutputStream(expectedLength > 0 ? (int) Math.min(expectedLength, framed.length) : 64);
+        int pos = 0;
+        while (pos < framed.length) {
+            int eol = indexOfCrlf(framed, pos);
+            if (eol < 0) {
+                throw new S3Exception(S3ErrorCode.INVALID_REQUEST, "Malformed aws-chunked body: no chunk header");
+            }
+            String header = new String(framed, pos, eol - pos, StandardCharsets.US_ASCII);
+            pos = eol + 2;
+            int semi = header.indexOf(';');
+            String sizeHex = (semi >= 0 ? header.substring(0, semi) : header).trim();
+            int size;
+            try {
+                size = Integer.parseInt(sizeHex, 16);
+            } catch (NumberFormatException e) {
+                throw new S3Exception(S3ErrorCode.INVALID_REQUEST, "Malformed aws-chunked size: " + sizeHex);
+            }
+            if (size == 0) {
+                break; // final chunk; trailers (if any) ignored.
+            }
+            if (pos + size > framed.length) {
+                throw new S3Exception(S3ErrorCode.INVALID_REQUEST, "Truncated aws-chunked chunk");
+            }
+            out.write(framed, pos, size);
+            pos += size;
+            // Each chunk's data is followed by a CRLF.
+            if (pos + 2 <= framed.length && framed[pos] == '\r' && framed[pos + 1] == '\n') {
+                pos += 2;
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static int indexOfCrlf(byte[] b, int from) {
+        for (int i = from; i + 1 < b.length; i++) {
+            if (b[i] == '\r' && b[i + 1] == '\n') {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/CandyStore.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/CandyStore.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.util.List;
+import java.util.Map;
+import me.predatorray.candybox.client.CandyboxClient.CandyInfo;
+import me.predatorray.candybox.client.CandyboxClient.Listing;
+
+/**
+ * The narrow seam the gateway's request handling depends on, exactly the subset of the Candybox client
+ * API the S3 surface needs. Production wires {@link CandyboxClientStore} (over the real
+ * {@code CandyboxClient}); unit tests pass a hand-written in-memory fake, so the Netty handler can be
+ * exercised with {@code EmbeddedChannel} and no sockets. Methods throw the Candybox exception hierarchy,
+ * which {@link ErrorMapper} translates to S3 errors.
+ */
+interface CandyStore {
+
+    void createBox(String box);
+
+    void deleteBox(String box);
+
+    boolean headBox(String box);
+
+    List<String> listBoxes();
+
+    void putCandy(String box, String key, byte[] data, String contentType,
+                  Map<String, String> userMetadata);
+
+    byte[] getCandy(String box, String key);
+
+    CandyInfo headCandy(String box, String key);
+
+    void deleteCandy(String box, String key);
+
+    /** Same-Box server-side copy; returns the destination's metadata. */
+    CandyInfo copyCandy(String box, String srcKey, String dstKey);
+
+    Listing listCandies(String box, String prefix, String startAfter, int maxKeys);
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/CandyboxClientStore.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/CandyboxClientStore.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.util.List;
+import java.util.Map;
+import me.predatorray.candybox.client.CandyboxClient;
+import me.predatorray.candybox.client.CandyboxClient.CandyInfo;
+import me.predatorray.candybox.client.CandyboxClient.Listing;
+
+/**
+ * The production {@link CandyStore}: delegates to a cluster-aware {@link CandyboxClient}. Object writes
+ * pass a {@code null} idempotency token (S3 PUT has no such concept). The gateway owns the client's
+ * lifecycle and closes it on shutdown.
+ */
+final class CandyboxClientStore implements CandyStore, AutoCloseable {
+
+    private final CandyboxClient client;
+
+    CandyboxClientStore(CandyboxClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void createBox(String box) {
+        client.createBox(box);
+    }
+
+    @Override
+    public void deleteBox(String box) {
+        client.deleteBox(box, false);
+    }
+
+    @Override
+    public boolean headBox(String box) {
+        return client.headBox(box);
+    }
+
+    @Override
+    public List<String> listBoxes() {
+        return client.listBoxes();
+    }
+
+    @Override
+    public void putCandy(String box, String key, byte[] data, String contentType,
+                         Map<String, String> userMetadata) {
+        client.putCandy(box, key, data, contentType, userMetadata, null);
+    }
+
+    @Override
+    public byte[] getCandy(String box, String key) {
+        return client.getCandy(box, key);
+    }
+
+    @Override
+    public CandyInfo headCandy(String box, String key) {
+        return client.headCandy(box, key);
+    }
+
+    @Override
+    public void deleteCandy(String box, String key) {
+        client.deleteCandy(box, key);
+    }
+
+    @Override
+    public CandyInfo copyCandy(String box, String srcKey, String dstKey) {
+        return client.copyCandy(box, srcKey, dstKey, null);
+    }
+
+    @Override
+    public Listing listCandies(String box, String prefix, String startAfter, int maxKeys) {
+        return client.listCandies(box, prefix, startAfter, maxKeys);
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/ErrorMapper.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/ErrorMapper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.util.Locale;
+import me.predatorray.candybox.common.exception.BoxAlreadyExistsException;
+import me.predatorray.candybox.common.exception.BoxNotEmptyException;
+import me.predatorray.candybox.common.exception.BoxNotFoundException;
+import me.predatorray.candybox.common.exception.BusyException;
+import me.predatorray.candybox.common.exception.CandyNotFoundException;
+import me.predatorray.candybox.common.exception.CandyboxException;
+import me.predatorray.candybox.common.exception.FencedException;
+import me.predatorray.candybox.common.exception.LimitExceededException;
+import me.predatorray.candybox.common.exception.NotOwnerException;
+import me.predatorray.candybox.common.exception.ValidationException;
+
+/**
+ * Translates a thrown {@link Throwable} into an {@link S3Exception} (HTTP status + S3 code). See
+ * {@code S3_GATEWAY_PLAN.md} §9 for the mapping table.
+ *
+ * <p>Two things make this fiddlier than a straight {@code instanceof} switch:
+ * <ul>
+ *   <li>{@link LimitExceededException} is a {@link ValidationException}, so it must be checked first;
+ *       and a bare {@code ValidationException} may be a bad bucket name (from {@code BoxName.of}) vs a
+ *       generic bad argument, distinguished by message.</li>
+ *   <li>The Candybox <em>client</em> collapses most server-side typed errors into a generic
+ *       {@code CandyboxException} whose message is {@code "<SimpleName>: <msg>"} (the server sends the
+ *       exception's simple name as the error type). So for a generic {@code CandyboxException} we sniff
+ *       that leading type token to recover {@code BoxAlreadyExists}, {@code BoxNotEmpty}, etc.</li>
+ * </ul>
+ */
+final class ErrorMapper {
+
+    private ErrorMapper() {
+    }
+
+    static S3Exception toS3(Throwable t) {
+        if (t instanceof S3Exception s3) {
+            return s3;
+        }
+        if (t instanceof LimitExceededException e) {
+            String msg = lower(e.getMessage());
+            S3ErrorCode code = msg.contains("key") ? S3ErrorCode.KEY_TOO_LONG : S3ErrorCode.ENTITY_TOO_LARGE;
+            return new S3Exception(code, e.getMessage(), e);
+        }
+        if (t instanceof ValidationException e) {
+            S3ErrorCode code = lower(e.getMessage()).contains("box name")
+                    ? S3ErrorCode.INVALID_BUCKET_NAME : S3ErrorCode.INVALID_ARGUMENT;
+            return new S3Exception(code, e.getMessage(), e);
+        }
+        if (t instanceof CandyNotFoundException e) {
+            return new S3Exception(S3ErrorCode.NO_SUCH_KEY, e.getMessage(), e);
+        }
+        if (t instanceof BoxNotFoundException e) {
+            return new S3Exception(S3ErrorCode.NO_SUCH_BUCKET, e.getMessage(), e);
+        }
+        if (t instanceof BoxNotEmptyException e) {
+            return new S3Exception(S3ErrorCode.BUCKET_NOT_EMPTY, e.getMessage(), e);
+        }
+        if (t instanceof BoxAlreadyExistsException e) {
+            return new S3Exception(S3ErrorCode.BUCKET_ALREADY_OWNED_BY_YOU, e.getMessage(), e);
+        }
+        if (t instanceof BusyException e) {
+            return new S3Exception(S3ErrorCode.SLOW_DOWN, e.getMessage(), e);
+        }
+        if (t instanceof NotOwnerException || t instanceof FencedException) {
+            // Ownership is in flux (handover/fencing). Retryable; the client re-drives to the new owner.
+            return new S3Exception(S3ErrorCode.SERVICE_UNAVAILABLE, t.getMessage(), t);
+        }
+        if (t instanceof CandyboxException e) {
+            return fromGenericMessage(e);
+        }
+        return new S3Exception(S3ErrorCode.INTERNAL_ERROR, "Internal error", t);
+    }
+
+    /**
+     * Maps a generic {@link CandyboxException} by sniffing the leading {@code "<TypeName>: "} token the
+     * client prepended from the server's error type.
+     */
+    private static S3Exception fromGenericMessage(CandyboxException e) {
+        String message = e.getMessage() == null ? "" : e.getMessage();
+        String type = message.indexOf(':') > 0 ? message.substring(0, message.indexOf(':')) : message;
+        S3ErrorCode code = switch (type.trim()) {
+            case "BoxAlreadyExistsException" -> S3ErrorCode.BUCKET_ALREADY_OWNED_BY_YOU;
+            case "BoxNotEmptyException" -> S3ErrorCode.BUCKET_NOT_EMPTY;
+            case "BoxNotFoundException" -> S3ErrorCode.NO_SUCH_BUCKET;
+            case "CandyNotFoundException" -> S3ErrorCode.NO_SUCH_KEY;
+            case "ValidationException" -> S3ErrorCode.INVALID_ARGUMENT;
+            case "LimitExceededException" -> S3ErrorCode.ENTITY_TOO_LARGE;
+            case "UnsupportedOperation" -> S3ErrorCode.NOT_IMPLEMENTED;
+            case "ProtocolError" -> S3ErrorCode.INVALID_REQUEST;
+            // The client collapses a server NotFoundResponse to the bare message "Not found"; in the S3
+            // surface that is overwhelmingly a missing key/bucket, so prefer 404 over 500.
+            default -> lower(message).contains("not found")
+                    ? S3ErrorCode.NO_SUCH_KEY : S3ErrorCode.INTERNAL_ERROR;
+        };
+        return new S3Exception(code, message, e);
+    }
+
+    private static String lower(String s) {
+        return s == null ? "" : s.toLowerCase(Locale.ROOT);
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/Etag.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/Etag.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+/**
+ * Derives the S3 {@code ETag} header from the CRC32C that Candybox already stores for every object.
+ *
+ * <p>The value is the unsigned 32-bit CRC32C left-padded to 32 hex chars (so it has the visual shape
+ * of an MD5 ETag), e.g. {@code crc32c=0x8f3a2b1c -> "000000008f3a2b1c"}. It is deterministic and stable
+ * across PUT/GET/HEAD/List for the same bytes, and needs no extra storage.
+ *
+ * <p><b>v1 limitation:</b> this is <em>not</em> the MD5 that real S3 returns, so a client that
+ * independently computes MD5 and strictly compares may warn. Real MD5 ETags are a deferred feature
+ * (they require a new object-metadata layer to persist the digest); when that lands, only this class
+ * changes. See {@code S3_GATEWAY_PLAN.md} §8, §16.
+ */
+final class Etag {
+
+    private Etag() {
+    }
+
+    /** Returns the quoted ETag string (including the surrounding double quotes) for a CRC32C value. */
+    static String of(int crc32c) {
+        return '"' + unquoted(crc32c) + '"';
+    }
+
+    /** Returns the bare ETag hex (no surrounding quotes), e.g. for XML list entries. */
+    static String unquoted(int crc32c) {
+        return String.format("%032x", crc32c & 0xffffffffL);
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/GatewayHealthServer.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/GatewayHealthServer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The gateway's orchestration endpoint, on the JDK {@link HttpServer} (no extra dependency), separate
+ * from the S3 listener so the load balancer can health-check it independently:
+ *
+ * <ul>
+ *   <li>{@code GET /healthz} — liveness; {@code 200} while the JVM is up.</li>
+ *   <li>{@code GET /readyz} — readiness; {@code 200} when the supplied predicate is true (bound and the
+ *       cluster client is usable), else {@code 503}.</li>
+ *   <li>{@code GET /metrics} — minimal Prometheus exposition.</li>
+ * </ul>
+ */
+final class GatewayHealthServer implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GatewayHealthServer.class);
+
+    private final HttpServer http;
+
+    GatewayHealthServer(int port, BooleanSupplier ready) {
+        try {
+            this.http = HttpServer.create(new InetSocketAddress(port), 0);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to bind gateway health server on port " + port, e);
+        }
+        http.createContext("/healthz", exchange -> respond(exchange, 200, "ok\n"));
+        http.createContext("/readyz", exchange -> {
+            boolean ok = ready.getAsBoolean();
+            respond(exchange, ok ? 200 : 503, ok ? "ready\n" : "not ready\n");
+        });
+        http.createContext("/metrics", exchange -> respond(exchange, 200,
+                "# HELP candybox_s3_gateway_up Gateway process up.\n"
+                        + "# TYPE candybox_s3_gateway_up gauge\n"
+                        + "candybox_s3_gateway_up 1\n"));
+        http.setExecutor(null);
+    }
+
+    void start() {
+        http.start();
+        LOG.info("Gateway health/metrics endpoint listening on port {}", http.getAddress().getPort());
+    }
+
+    int port() {
+        return http.getAddress().getPort();
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @Override
+    public void close() {
+        http.stop(0);
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3ErrorCode.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3ErrorCode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+/**
+ * The subset of S3 error codes the gateway emits, each paired with its HTTP status and a default
+ * human-readable message. Rendered into the standard S3 {@code <Error>} XML body. See
+ * {@code S3_GATEWAY_PLAN.md} §9.
+ */
+enum S3ErrorCode {
+    NO_SUCH_KEY(404, "NoSuchKey", "The specified key does not exist."),
+    NO_SUCH_BUCKET(404, "NoSuchBucket", "The specified bucket does not exist."),
+    BUCKET_ALREADY_OWNED_BY_YOU(409, "BucketAlreadyOwnedByYou",
+            "Your previous request to create the named bucket succeeded and you already own it."),
+    BUCKET_NOT_EMPTY(409, "BucketNotEmpty", "The bucket you tried to delete is not empty."),
+    INVALID_BUCKET_NAME(400, "InvalidBucketName", "The specified bucket is not valid."),
+    INVALID_ARGUMENT(400, "InvalidArgument", "Invalid Argument."),
+    INVALID_REQUEST(400, "InvalidRequest", "Invalid Request."),
+    KEY_TOO_LONG(400, "KeyTooLongError", "Your key is too long."),
+    ENTITY_TOO_LARGE(400, "EntityTooLarge", "Your proposed upload exceeds the maximum allowed object size."),
+    MALFORMED_XML(400, "MalformedXML", "The XML you provided was not well-formed or did not validate."),
+    METHOD_NOT_ALLOWED(405, "MethodNotAllowed", "The specified method is not allowed against this resource."),
+    NOT_IMPLEMENTED(501, "NotImplemented", "A header or operation you provided is not implemented."),
+    SLOW_DOWN(503, "SlowDown", "Please reduce your request rate."),
+    SERVICE_UNAVAILABLE(503, "ServiceUnavailable", "Reduce your request rate."),
+    INTERNAL_ERROR(500, "InternalError", "We encountered an internal error. Please try again.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String defaultMessage;
+
+    S3ErrorCode(int httpStatus, String code, String defaultMessage) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+    }
+
+    int httpStatus() {
+        return httpStatus;
+    }
+
+    String code() {
+        return code;
+    }
+
+    String defaultMessage() {
+        return defaultMessage;
+    }
+
+    /** Whether a client should retry after backing off (drives the {@code Retry-After} header). */
+    boolean retryable() {
+        return this == SLOW_DOWN || this == SERVICE_UNAVAILABLE;
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Exception.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Exception.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+/**
+ * A failure that should be rendered to the client as an S3 {@code <Error>} response. Carries the
+ * {@link S3ErrorCode} (HTTP status + code) and an optional message overriding the code's default.
+ */
+final class S3Exception extends RuntimeException {
+
+    private final S3ErrorCode error;
+
+    S3Exception(S3ErrorCode error) {
+        this(error, error.defaultMessage(), null);
+    }
+
+    S3Exception(S3ErrorCode error, String message) {
+        this(error, message, null);
+    }
+
+    S3Exception(S3ErrorCode error, String message, Throwable cause) {
+        super(message, cause);
+        this.error = error;
+    }
+
+    S3ErrorCode error() {
+        return error;
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Gateway.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Gateway.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import me.predatorray.candybox.client.CandyboxClient;
+
+/**
+ * Public facade for embedding a running S3 gateway over an existing cluster-aware {@link CandyboxClient}
+ * — used by the process entrypoint ({@link S3GatewayMain}) and by integration tests that drive the
+ * gateway against a real node. Does <em>not</em> own the supplied client's lifecycle (the caller closes
+ * it); {@link #close()} stops only the Netty server.
+ */
+public final class S3Gateway implements AutoCloseable {
+
+    private final S3GatewayServer server;
+
+    public S3Gateway(S3GatewayConfig config, CandyboxClient client) {
+        this.server = new S3GatewayServer(config, new CandyboxClientStore(client));
+    }
+
+    /** Binds and starts serving. */
+    public void start() {
+        server.start();
+    }
+
+    /** The actual bound port (useful when configured with port 0). */
+    public int port() {
+        return server.port();
+    }
+
+    @Override
+    public void close() {
+        server.close();
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayConfig.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayConfig.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Deployment-facing configuration for the S3 gateway process, loaded from a {@code .properties} file
+ * with environment-variable overrides — the same 12-factor convention as the storage node's
+ * {@code ServerConfig}: each key maps to {@code CANDYBOX_<KEY>} (dots to underscores, upper-cased) and
+ * the environment wins. See {@code S3_GATEWAY_PLAN.md} §11.
+ */
+public final class S3GatewayConfig {
+
+    /** Default S3 HTTP listen port (plain HTTP; TLS is terminated at the load balancer). */
+    public static final int DEFAULT_PORT = 9711;
+    /** Default HTTP health/metrics port. */
+    public static final int DEFAULT_HEALTH_PORT = 9712;
+    /** Default single-PUT ceiling (no multipart in v1): 5 GiB. */
+    public static final long DEFAULT_MAX_OBJECT_BYTES = 5L * 1024 * 1024 * 1024;
+
+    private static final String ENV_PREFIX = "CANDYBOX_";
+
+    private final String bindHost;
+    private final int bindPort;
+    private final int healthPort;
+    private final String zookeeperConnect;
+    private final String region;
+    private final long maxObjectBytes;
+    private final int workerThreads;
+    private final long routerCacheTtlMillis;
+
+    private S3GatewayConfig(Builder b) {
+        this.bindHost = b.bindHost;
+        this.bindPort = b.bindPort;
+        this.healthPort = b.healthPort;
+        this.zookeeperConnect = b.zookeeperConnect;
+        this.region = b.region;
+        this.maxObjectBytes = b.maxObjectBytes;
+        this.workerThreads = b.workerThreads;
+        this.routerCacheTtlMillis = b.routerCacheTtlMillis;
+    }
+
+    public static S3GatewayConfig load(Path propertiesFile) {
+        Properties props = new Properties();
+        try (InputStream in = Files.newInputStream(propertiesFile)) {
+            props.load(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read config file: " + propertiesFile, e);
+        }
+        return fromProperties(props, System.getenv());
+    }
+
+    public static S3GatewayConfig fromProperties(Properties props, Map<String, String> env) {
+        Resolver r = new Resolver(props, env);
+        HostPort bind = HostPort.parse(r.get("s3.bind").orElse("0.0.0.0:" + DEFAULT_PORT), DEFAULT_PORT);
+        return new Builder()
+                .bindHost(bind.host)
+                .bindPort(bind.port)
+                .healthPort(r.getInt("health.port").orElse(DEFAULT_HEALTH_PORT))
+                .zookeeperConnect(r.require("zookeeper.connect"))
+                .region(r.get("s3.region").orElse("us-east-1"))
+                .maxObjectBytes(r.getLong("s3.max-object-bytes").orElse(DEFAULT_MAX_OBJECT_BYTES))
+                .workerThreads(r.getInt("s3.worker-threads")
+                        .orElse(Math.max(4, Runtime.getRuntime().availableProcessors() * 2)))
+                .routerCacheTtlMillis(r.getLong("s3.router-cache-ttl-ms").orElse(5_000L))
+                .build();
+    }
+
+    public String bindHost() {
+        return bindHost;
+    }
+
+    public int bindPort() {
+        return bindPort;
+    }
+
+    public int healthPort() {
+        return healthPort;
+    }
+
+    public String zookeeperConnect() {
+        return zookeeperConnect;
+    }
+
+    public String region() {
+        return region;
+    }
+
+    public long maxObjectBytes() {
+        return maxObjectBytes;
+    }
+
+    public int workerThreads() {
+        return workerThreads;
+    }
+
+    public long routerCacheTtlMillis() {
+        return routerCacheTtlMillis;
+    }
+
+    private record HostPort(String host, int port) {
+        static HostPort parse(String value, int defaultPort) {
+            int colon = value.lastIndexOf(':');
+            if (colon < 0) {
+                return new HostPort(value, defaultPort);
+            }
+            String host = value.substring(0, colon);
+            int port = Integer.parseInt(value.substring(colon + 1).trim());
+            return new HostPort(host.isEmpty() ? "0.0.0.0" : host, port);
+        }
+    }
+
+    private static final class Resolver {
+        private final Properties props;
+        private final Map<String, String> env;
+
+        Resolver(Properties props, Map<String, String> env) {
+            this.props = props;
+            this.env = env;
+        }
+
+        Optional<String> get(String key) {
+            String envVal = env.get(ENV_PREFIX + key.toUpperCase().replace('.', '_').replace('-', '_'));
+            if (envVal != null && !envVal.isBlank()) {
+                return Optional.of(envVal.trim());
+            }
+            String fileVal = props.getProperty(key);
+            return (fileVal != null && !fileVal.isBlank()) ? Optional.of(fileVal.trim()) : Optional.empty();
+        }
+
+        String require(String key) {
+            return get(key).orElseThrow(() -> new IllegalArgumentException(
+                    "Missing required config key '" + key + "' (or env "
+                            + ENV_PREFIX + key.toUpperCase().replace('.', '_').replace('-', '_') + ")"));
+        }
+
+        Optional<Integer> getInt(String key) {
+            return get(key).map(Integer::parseInt);
+        }
+
+        Optional<Long> getLong(String key) {
+            return get(key).map(Long::parseLong);
+        }
+    }
+
+    static final class Builder {
+        private String bindHost = "0.0.0.0";
+        private int bindPort = DEFAULT_PORT;
+        private int healthPort = DEFAULT_HEALTH_PORT;
+        private String zookeeperConnect;
+        private String region = "us-east-1";
+        private long maxObjectBytes = DEFAULT_MAX_OBJECT_BYTES;
+        private int workerThreads = 8;
+        private long routerCacheTtlMillis = 5_000L;
+
+        Builder bindHost(String v) {
+            this.bindHost = v;
+            return this;
+        }
+
+        Builder bindPort(int v) {
+            this.bindPort = v;
+            return this;
+        }
+
+        Builder healthPort(int v) {
+            this.healthPort = v;
+            return this;
+        }
+
+        Builder zookeeperConnect(String v) {
+            this.zookeeperConnect = v;
+            return this;
+        }
+
+        Builder region(String v) {
+            this.region = v;
+            return this;
+        }
+
+        Builder maxObjectBytes(long v) {
+            this.maxObjectBytes = v;
+            return this;
+        }
+
+        Builder workerThreads(int v) {
+            this.workerThreads = v;
+            return this;
+        }
+
+        Builder routerCacheTtlMillis(long v) {
+            this.routerCacheTtlMillis = v;
+            return this;
+        }
+
+        S3GatewayConfig build() {
+            return new S3GatewayConfig(this);
+        }
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayMain.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayMain.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import me.predatorray.candybox.client.CandyboxClient;
+import me.predatorray.candybox.common.SystemClock;
+import me.predatorray.candybox.common.config.CandyboxConfig;
+import me.predatorray.candybox.coordination.CoordinationService;
+import me.predatorray.candybox.coordination.zk.ZooKeeperCoordinationService;
+import me.predatorray.candybox.protocol.transport.TcpTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Process entrypoint for the S3 gateway: turns an {@link S3GatewayConfig} into a running, stateless,
+ * cluster-aware gateway — a {@link TcpTransport} + ZooKeeper-backed {@link CoordinationService} behind a
+ * cluster {@link CandyboxClient}, fronted by the Netty {@link S3GatewayServer} and a
+ * {@link GatewayHealthServer}.
+ *
+ * <p>Runs in the foreground; SIGTERM/Ctrl-C marks it not-ready (so the load balancer drains it) and
+ * closes every component in reverse order.
+ */
+public final class S3GatewayMain {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3GatewayMain.class);
+
+    private S3GatewayMain() {
+    }
+
+    public static void main(String[] args) {
+        Path confFile = resolveConfigFile(args);
+        LOG.info("Loading S3 gateway configuration from {}", confFile.toAbsolutePath());
+        run(S3GatewayConfig.load(confFile));
+    }
+
+    private static Path resolveConfigFile(String[] args) {
+        if (args.length > 0 && !args[0].isBlank()) {
+            return Path.of(args[0]);
+        }
+        String confDir = System.getenv("CANDYBOX_CONF_DIR");
+        if (confDir != null && !confDir.isBlank()) {
+            return Path.of(confDir, "candybox-s3-gateway.properties");
+        }
+        return Path.of("conf", "candybox-s3-gateway.properties");
+    }
+
+    static void run(S3GatewayConfig config) {
+        LOG.info("Starting Candybox S3 gateway (bind={}:{}, zk={}, region={})", config.bindHost(),
+                config.bindPort(), config.zookeeperConnect(), config.region());
+
+        TcpTransport transport = new TcpTransport();
+        CoordinationService coordination =
+                new ZooKeeperCoordinationService(config.zookeeperConnect(), SystemClock.INSTANCE);
+        CandyboxConfig clientConfig = CandyboxConfig.builder()
+                .routerCacheTtlMillis(config.routerCacheTtlMillis())
+                .build();
+        CandyboxClient client = new CandyboxClient(transport, coordination, clientConfig);
+
+        S3Gateway gateway = new S3Gateway(config, client);
+        gateway.start();
+
+        AtomicBoolean ready = new AtomicBoolean(true);
+        GatewayHealthServer health = new GatewayHealthServer(config.healthPort(), ready::get);
+        health.start();
+
+        LOG.info("Candybox S3 gateway is up: S3 on {}, health on {}", gateway.port(), health.port());
+
+        CountDownLatch shutdown = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOG.info("Shutdown signal received; draining S3 gateway");
+            ready.set(false);
+            closeQuietly("health server", health);
+            closeQuietly("S3 gateway", gateway);
+            closeQuietly("candybox client", client);
+            closeQuietly("coordination", coordination);
+            closeQuietly("transport", transport);
+            shutdown.countDown();
+        }, "candybox-s3-gateway-shutdown"));
+
+        try {
+            shutdown.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        LOG.info("Candybox S3 gateway stopped");
+    }
+
+    private static void closeQuietly(String what, AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            LOG.warn("Error closing {}: {}", what, e.toString());
+        }
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayServer.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3GatewayServer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.net.InetSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Netty bootstrap for the S3 gateway: a boss/worker event-loop pair handling HTTP framing, and a
+ * dedicated blocking {@link EventExecutorGroup} on which {@link S3Handler} runs so the synchronous
+ * Candybox client calls never block an I/O thread.
+ *
+ * <p>v1 aggregates each request into a {@code FullHttpRequest} (bounded by the configured max object
+ * size, itself capped to ~2 GiB by the aggregator's int limit), consistent with the client's current
+ * buffer-based API. True streaming awaits client streaming support — see {@code S3_GATEWAY_PLAN.md} §4.
+ */
+final class S3GatewayServer implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3GatewayServer.class);
+
+    private final S3GatewayConfig config;
+    private final CandyStore store;
+
+    private EventLoopGroup boss;
+    private EventLoopGroup workers;
+    private EventExecutorGroup blockingGroup;
+    private Channel channel;
+
+    S3GatewayServer(S3GatewayConfig config, CandyStore store) {
+        this.config = config;
+        this.store = store;
+    }
+
+    void start() {
+        int maxContent = (int) Math.min(config.maxObjectBytes(), Integer.MAX_VALUE - 8L);
+        boss = new NioEventLoopGroup(1);
+        workers = new NioEventLoopGroup();
+        blockingGroup = new DefaultEventExecutorGroup(config.workerThreads());
+
+        ServerBootstrap bootstrap = new ServerBootstrap()
+                .group(boss, workers)
+                .channel(NioServerSocketChannel.class)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                        ch.pipeline().addLast(new HttpServerCodec());
+                        ch.pipeline().addLast(new HttpObjectAggregator(maxContent));
+                        // Run the (blocking) handler off the I/O event loop.
+                        ch.pipeline().addLast(blockingGroup, new S3Handler(store, config));
+                    }
+                });
+
+        channel = bootstrap.bind(new InetSocketAddress(config.bindHost(), config.bindPort()))
+                .syncUninterruptibly().channel();
+        LOG.info("S3 gateway listening on {}:{}", config.bindHost(), port());
+    }
+
+    int port() {
+        return ((InetSocketAddress) channel.localAddress()).getPort();
+    }
+
+    @Override
+    public void close() {
+        if (channel != null) {
+            channel.close().syncUninterruptibly();
+        }
+        if (boss != null) {
+            boss.shutdownGracefully();
+        }
+        if (workers != null) {
+            workers.shutdownGracefully();
+        }
+        if (blockingGroup != null) {
+            blockingGroup.shutdownGracefully();
+        }
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Handler.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Handler.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import me.predatorray.candybox.client.CandyboxClient.CandyInfo;
+import me.predatorray.candybox.client.CandyboxClient.Listing;
+import me.predatorray.candybox.common.checksum.Crc32c;
+import me.predatorray.candybox.s3.S3Router.S3Action;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Netty inbound handler: turns an aggregated {@link FullHttpRequest} into Candybox client calls and
+ * writes back an S3-shaped response. Added to the pipeline behind a blocking {@code EventExecutorGroup}
+ * (see {@link S3GatewayServer}) so the synchronous {@link CandyStore} calls never block an I/O event
+ * loop.
+ *
+ * <p>v1 buffers whole request/response bodies (the underlying client API is itself buffer-based today),
+ * path-style addressing only, anonymous (the {@code Authorization} header is accepted and ignored). See
+ * {@code S3_GATEWAY_PLAN.md}.
+ */
+final class S3Handler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3Handler.class);
+    private static final String META_PREFIX = "x-amz-meta-";
+    private static final int DEFAULT_MAX_KEYS = 1000;
+
+    private final CandyStore store;
+    private final S3GatewayConfig config;
+
+    S3Handler(CandyStore store, S3GatewayConfig config) {
+        this.store = store;
+        this.config = config;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+        String requestId = UUID.randomUUID().toString();
+        String method = request.method().name().toUpperCase(Locale.ROOT);
+        QueryStringDecoder decoder = new QueryStringDecoder(request.uri());
+        PathParts parts = PathParts.parse(decoder.rawPath());
+        Set<String> queryNames = new LinkedHashSet<>();
+        decoder.parameters().keySet().forEach(k -> queryNames.add(k.toLowerCase(Locale.ROOT)));
+        String resource = decoder.rawPath();
+
+        try {
+            S3Action action = S3Router.route(method, parts.bucket(), parts.key(), queryNames);
+            dispatch(ctx, request, action, parts, decoder, requestId);
+        } catch (S3Exception e) {
+            sendError(ctx, request, e.error(), e.getMessage(), resource, requestId);
+        } catch (RuntimeException e) {
+            S3Exception mapped = ErrorMapper.toS3(e);
+            if (mapped.error() == S3ErrorCode.INTERNAL_ERROR) {
+                LOG.warn("Unexpected error handling {} {} (req {})", method, resource, requestId, e);
+            }
+            sendError(ctx, request, mapped.error(), mapped.getMessage(), resource, requestId);
+        }
+    }
+
+    private void dispatch(ChannelHandlerContext ctx, FullHttpRequest request, S3Action action,
+                          PathParts parts, QueryStringDecoder decoder, String requestId) {
+        switch (action) {
+            case LIST_BUCKETS -> sendXml(ctx, request, HttpResponseStatus.OK,
+                    S3Xml.listAllMyBuckets(store.listBoxes()), requestId);
+            case CREATE_BUCKET -> {
+                store.createBox(parts.bucket());
+                FullHttpResponse r = empty(HttpResponseStatus.OK);
+                r.headers().set(HttpHeaderNames.LOCATION, "/" + parts.bucket());
+                send(ctx, request, r, requestId);
+            }
+            case DELETE_BUCKET -> {
+                store.deleteBox(parts.bucket());
+                send(ctx, request, empty(HttpResponseStatus.NO_CONTENT), requestId);
+            }
+            case HEAD_BUCKET -> {
+                if (store.headBox(parts.bucket())) {
+                    send(ctx, request, empty(HttpResponseStatus.OK), requestId);
+                } else {
+                    sendError(ctx, request, S3ErrorCode.NO_SUCH_BUCKET, null, "/" + parts.bucket(), requestId);
+                }
+            }
+            case LIST_OBJECTS -> listObjects(ctx, request, parts.bucket(), decoder, requestId);
+            case DELETE_OBJECTS -> deleteObjects(ctx, request, parts.bucket(), requestId);
+            case GET_BUCKET_LOCATION -> sendXml(ctx, request, HttpResponseStatus.OK,
+                    S3Xml.locationConstraint(config.region()), requestId);
+            case GET_BUCKET_VERSIONING -> sendXml(ctx, request, HttpResponseStatus.OK,
+                    S3Xml.versioningConfiguration(), requestId);
+            case GET_BUCKET_ACL -> sendXml(ctx, request, HttpResponseStatus.OK,
+                    S3Xml.accessControlPolicy(), requestId);
+            case PUT_OBJECT -> putOrCopy(ctx, request, parts, requestId);
+            case GET_OBJECT -> getObject(ctx, request, parts, requestId);
+            case HEAD_OBJECT -> headObject(ctx, request, parts, requestId);
+            case DELETE_OBJECT -> {
+                deleteObjectIdempotent(parts.bucket(), parts.key());
+                send(ctx, request, empty(HttpResponseStatus.NO_CONTENT), requestId);
+            }
+            case UNSUPPORTED -> sendError(ctx, request, S3ErrorCode.NOT_IMPLEMENTED, null,
+                    decoder.rawPath(), requestId);
+            default -> sendError(ctx, request, S3ErrorCode.NOT_IMPLEMENTED, null, decoder.rawPath(), requestId);
+        }
+    }
+
+    // ---- objects ---------------------------------------------------------------------------
+
+    private void putOrCopy(ChannelHandlerContext ctx, FullHttpRequest request, PathParts parts,
+                           String requestId) {
+        String copySource = request.headers().get("x-amz-copy-source");
+        if (copySource != null && !copySource.isBlank()) {
+            copyObject(ctx, request, parts, copySource, requestId);
+            return;
+        }
+        byte[] body = bodyBytes(request);
+        if (body.length > config.maxObjectBytes()) {
+            throw new S3Exception(S3ErrorCode.ENTITY_TOO_LARGE,
+                    "Object exceeds the configured maximum of " + config.maxObjectBytes() + " bytes");
+        }
+        String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        if (contentType == null || contentType.isBlank()) {
+            contentType = "application/octet-stream";
+        }
+        Map<String, String> userMeta = userMetadata(request);
+        store.putCandy(parts.bucket(), parts.key(), body, contentType, userMeta);
+
+        FullHttpResponse r = empty(HttpResponseStatus.OK);
+        r.headers().set(HttpHeaderNames.ETAG, Etag.of(Crc32c.of(body)));
+        send(ctx, request, r, requestId);
+    }
+
+    private void copyObject(ChannelHandlerContext ctx, FullHttpRequest request, PathParts parts,
+                            String copySource, String requestId) {
+        PathParts src = PathParts.parse(stripLeadingSlash(uriDecode(copySource)));
+        if (src.bucket() == null || src.key() == null || src.key().isEmpty()) {
+            throw new S3Exception(S3ErrorCode.INVALID_ARGUMENT, "Malformed x-amz-copy-source");
+        }
+        if (!src.bucket().equals(parts.bucket())) {
+            // Candybox copyCandy is intra-Box only; cross-bucket copy is deferred (plan §16).
+            throw new S3Exception(S3ErrorCode.NOT_IMPLEMENTED, "Cross-bucket copy is not supported");
+        }
+        CandyInfo info = store.copyCandy(parts.bucket(), src.key(), parts.key());
+        sendXml(ctx, request, HttpResponseStatus.OK,
+                S3Xml.copyObjectResult(Etag.unquoted(info.crc32c()), info.createdAtMillis()), requestId);
+    }
+
+    private void getObject(ChannelHandlerContext ctx, FullHttpRequest request, PathParts parts,
+                           String requestId) {
+        requireKey(parts);
+        // v1: Range is ignored; the whole object is returned with 200 (plan §16).
+        CandyInfo info = store.headCandy(parts.bucket(), parts.key());
+        byte[] data = store.getCandy(parts.bucket(), parts.key());
+        FullHttpResponse r = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.wrappedBuffer(data));
+        applyObjectHeaders(r, info);
+        send(ctx, request, r, requestId);
+    }
+
+    private void headObject(ChannelHandlerContext ctx, FullHttpRequest request, PathParts parts,
+                            String requestId) {
+        requireKey(parts);
+        CandyInfo info = store.headCandy(parts.bucket(), parts.key());
+        FullHttpResponse r = empty(HttpResponseStatus.OK);
+        applyObjectHeaders(r, info);
+        // HEAD carries the headers (incl. Content-Length) but no body.
+        r.headers().set(HttpHeaderNames.CONTENT_LENGTH, Long.toString(info.contentLength()));
+        send(ctx, request, r, requestId, true);
+    }
+
+    private void applyObjectHeaders(FullHttpResponse r, CandyInfo info) {
+        String contentType = info.contentType();
+        r.headers().set(HttpHeaderNames.CONTENT_TYPE,
+                (contentType == null || contentType.isBlank()) ? "application/octet-stream" : contentType);
+        r.headers().set(HttpHeaderNames.ETAG, Etag.of(info.crc32c()));
+        r.headers().set(HttpHeaderNames.LAST_MODIFIED, httpDate(info.createdAtMillis()));
+        r.headers().set(HttpHeaderNames.ACCEPT_RANGES, "bytes");
+        if (info.userMetadata() != null) {
+            info.userMetadata().forEach((k, v) -> r.headers().set(META_PREFIX + k, v));
+        }
+    }
+
+    private void deleteObjectIdempotent(String bucket, String key) {
+        try {
+            store.deleteCandy(bucket, key);
+        } catch (RuntimeException e) {
+            // DeleteObject is idempotent in S3: a missing key is still a success.
+            S3Exception mapped = ErrorMapper.toS3(e);
+            if (mapped.error() != S3ErrorCode.NO_SUCH_KEY) {
+                throw e;
+            }
+        }
+    }
+
+    // ---- listing ---------------------------------------------------------------------------
+
+    private void listObjects(ChannelHandlerContext ctx, FullHttpRequest request, String bucket,
+                             QueryStringDecoder decoder, String requestId) {
+        Map<String, List<String>> q = decoder.parameters();
+        String prefix = first(q, "prefix", "");
+        String delimiter = first(q, "delimiter", null);
+        int maxKeys = clampMaxKeys(first(q, "max-keys", null));
+        String continuationToken = first(q, "continuation-token", null);
+        String startAfterParam = first(q, "start-after", null);
+        String startAfter = continuationToken != null ? decodeToken(continuationToken) : startAfterParam;
+
+        Listing listing = store.listCandies(bucket, prefix, startAfter, maxKeys);
+
+        List<S3Xml.Content> contents = new ArrayList<>();
+        Set<String> commonPrefixes = new LinkedHashSet<>();
+        for (Listing.Entry e : listing.entries()) {
+            String key = e.key();
+            if (delimiter != null) {
+                int from = prefix == null ? 0 : prefix.length();
+                int idx = key.indexOf(delimiter, from);
+                if (idx >= 0) {
+                    commonPrefixes.add(key.substring(0, idx + delimiter.length()));
+                    continue;
+                }
+            }
+            // The listing API returns no CRC32C, so list entries carry no ETag in v1 (clients tolerate
+            // its absence). A HEAD on the individual key returns the deterministic ETag.
+            contents.add(new S3Xml.Content(key, e.contentLength(), e.createdAtMillis(), null));
+        }
+        String nextToken = listing.isTruncated() ? encodeToken(listing.nextStartAfter()) : null;
+        String xml = S3Xml.listBucket(bucket, prefix, delimiter, maxKeys, contents,
+                new ArrayList<>(commonPrefixes), continuationToken, nextToken, startAfterParam);
+        sendXml(ctx, request, HttpResponseStatus.OK, xml, requestId);
+    }
+
+    private void deleteObjects(ChannelHandlerContext ctx, FullHttpRequest request, String bucket,
+                               String requestId) {
+        S3RequestXml.DeleteRequest req = S3RequestXml.parseDelete(bodyBytes(request));
+        List<String> deleted = new ArrayList<>();
+        List<String[]> errors = new ArrayList<>();
+        for (String key : req.keys()) {
+            try {
+                deleteObjectIdempotent(bucket, key);
+                deleted.add(key);
+            } catch (RuntimeException e) {
+                S3Exception mapped = ErrorMapper.toS3(e);
+                errors.add(new String[]{key, mapped.error().code(), mapped.getMessage()});
+            }
+        }
+        // In quiet mode S3 omits successfully-deleted keys from the response (errors are still listed).
+        List<String> reported = req.quiet() ? List.of() : deleted;
+        sendXml(ctx, request, HttpResponseStatus.OK, S3Xml.deleteResult(reported, errors), requestId);
+    }
+
+    // ---- request parsing helpers -----------------------------------------------------------
+
+    private byte[] bodyBytes(FullHttpRequest request) {
+        byte[] raw = new byte[request.content().readableBytes()];
+        request.content().getBytes(request.content().readerIndex(), raw);
+        String encoding = request.headers().get(HttpHeaderNames.CONTENT_ENCODING);
+        String sha256 = request.headers().get("x-amz-content-sha256");
+        if (AwsChunked.isChunked(encoding, sha256)) {
+            long decodedLen = parseLong(request.headers().get("x-amz-decoded-content-length"), -1);
+            return AwsChunked.decode(raw, decodedLen);
+        }
+        return raw;
+    }
+
+    private static Map<String, String> userMetadata(FullHttpRequest request) {
+        Map<String, String> meta = new LinkedHashMap<>();
+        for (Map.Entry<String, String> h : request.headers()) {
+            String name = h.getKey().toLowerCase(Locale.ROOT);
+            if (name.startsWith(META_PREFIX) && name.length() > META_PREFIX.length()) {
+                meta.put(name.substring(META_PREFIX.length()), h.getValue());
+            }
+        }
+        return meta;
+    }
+
+    private static void requireKey(PathParts parts) {
+        if (parts.key() == null || parts.key().isEmpty()) {
+            throw new S3Exception(S3ErrorCode.METHOD_NOT_ALLOWED, "Missing object key");
+        }
+    }
+
+    private static int clampMaxKeys(String raw) {
+        if (raw == null) {
+            return DEFAULT_MAX_KEYS;
+        }
+        try {
+            int v = Integer.parseInt(raw.trim());
+            return Math.max(1, Math.min(DEFAULT_MAX_KEYS, v));
+        } catch (NumberFormatException e) {
+            return DEFAULT_MAX_KEYS;
+        }
+    }
+
+    private static String first(Map<String, List<String>> q, String key, String dflt) {
+        List<String> vs = q.get(key);
+        return (vs == null || vs.isEmpty()) ? dflt : vs.get(0);
+    }
+
+    private static String encodeToken(String startAfter) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(startAfter.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decodeToken(String token) {
+        try {
+            return new String(Base64.getUrlDecoder().decode(token), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new S3Exception(S3ErrorCode.INVALID_ARGUMENT, "Invalid continuation-token");
+        }
+    }
+
+    private static long parseLong(String s, long dflt) {
+        if (s == null) {
+            return dflt;
+        }
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return dflt;
+        }
+    }
+
+    private static String stripLeadingSlash(String s) {
+        return s.startsWith("/") ? s.substring(1) : s;
+    }
+
+    // ---- response writing ------------------------------------------------------------------
+
+    private void sendXml(ChannelHandlerContext ctx, FullHttpRequest request, HttpResponseStatus status,
+                         String xml, String requestId) {
+        FullHttpResponse r = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status,
+                Unpooled.copiedBuffer(xml, StandardCharsets.UTF_8));
+        r.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/xml");
+        send(ctx, request, r, requestId);
+    }
+
+    private void sendError(ChannelHandlerContext ctx, FullHttpRequest request, S3ErrorCode error,
+                           String message, String resource, String requestId) {
+        String msg = message == null ? error.defaultMessage() : message;
+        FullHttpResponse r = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.valueOf(error.httpStatus()),
+                Unpooled.copiedBuffer(S3Xml.error(error, msg, resource, requestId), StandardCharsets.UTF_8));
+        r.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/xml");
+        if (error.retryable()) {
+            r.headers().set(HttpHeaderNames.RETRY_AFTER, "1");
+        }
+        send(ctx, request, r, requestId, isHead(request));
+    }
+
+    private FullHttpResponse empty(HttpResponseStatus status) {
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.EMPTY_BUFFER);
+    }
+
+    private void send(ChannelHandlerContext ctx, FullHttpRequest request, FullHttpResponse response,
+                      String requestId) {
+        send(ctx, request, response, requestId, isHead(request));
+    }
+
+    /**
+     * Writes the response, honoring keep-alive. When {@code headOnly} is true the body buffer is
+     * cleared but the (already-set) {@code Content-Length} is preserved, as HTTP requires for HEAD.
+     */
+    private void send(ChannelHandlerContext ctx, FullHttpRequest request, FullHttpResponse response,
+                      String requestId, boolean headOnly) {
+        response.headers().set("x-amz-request-id", requestId);
+        response.headers().set(HttpHeaderNames.SERVER, "Candybox");
+        boolean keepAlive = HttpUtil.isKeepAlive(request);
+        if (headOnly) {
+            String declared = response.headers().get(HttpHeaderNames.CONTENT_LENGTH, "0");
+            response.content().clear();
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, declared);
+        } else {
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+        }
+        if (keepAlive) {
+            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            ctx.writeAndFlush(response);
+        } else {
+            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    private static boolean isHead(FullHttpRequest request) {
+        return "HEAD".equalsIgnoreCase(request.method().name());
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        LOG.warn("Channel exception", cause);
+        ctx.close();
+    }
+
+    private static String httpDate(long epochMillis) {
+        return java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(java.time.ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(epochMillis),
+                        java.time.ZoneOffset.UTC));
+    }
+
+    private static String uriDecode(String s) {
+        return java.net.URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+
+    /** Path-style split of a decoded request path into bucket + key (both may be null/empty). */
+    record PathParts(String bucket, String key) {
+        static PathParts parse(String rawPath) {
+            String p = stripLeading(rawPath);
+            if (p.isEmpty()) {
+                return new PathParts(null, null);
+            }
+            int slash = p.indexOf('/');
+            if (slash < 0) {
+                return new PathParts(percentDecode(p), null);
+            }
+            String bucket = percentDecode(p.substring(0, slash));
+            String key = percentDecode(p.substring(slash + 1));
+            return new PathParts(bucket, key);
+        }
+
+        private static String stripLeading(String s) {
+            return s.startsWith("/") ? s.substring(1) : s;
+        }
+    }
+
+    /**
+     * Percent-decodes a path component (UTF-8) WITHOUT treating {@code '+'} as a space — in an S3 key a
+     * literal {@code '+'} must survive. Slashes already in the string are preserved.
+     */
+    static String percentDecode(String s) {
+        if (s.indexOf('%') < 0) {
+            return s;
+        }
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '%' && i + 2 < s.length()) {
+                int hi = Character.digit(s.charAt(i + 1), 16);
+                int lo = Character.digit(s.charAt(i + 2), 16);
+                if (hi >= 0 && lo >= 0) {
+                    out.write((hi << 4) + lo);
+                    i += 2;
+                    continue;
+                }
+            }
+            // Multi-byte chars are emitted as UTF-8 bytes.
+            byte[] bytes = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+            out.write(bytes, 0, bytes.length);
+        }
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3RequestXml.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3RequestXml.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * Parses the (untrusted) S3 request XML bodies the gateway accepts, using the JDK StAX reader rather
+ * than ad-hoc string scanning. The factory is hardened against XXE and entity-expansion attacks by
+ * disabling DTDs and external entities — mandatory since the body comes straight from the client.
+ *
+ * <p>Currently only {@code DeleteObjects} (a {@code POST ?delete} with a {@code <Delete>} body) has a
+ * request payload.
+ */
+final class S3RequestXml {
+
+    /** A {@code DeleteObjects} request: the keys to delete and whether the response should be quiet. */
+    record DeleteRequest(List<String> keys, boolean quiet) {
+    }
+
+    private static final XMLInputFactory INPUT_FACTORY = hardenedInputFactory();
+
+    private S3RequestXml() {
+    }
+
+    private static XMLInputFactory hardenedInputFactory() {
+        XMLInputFactory f = XMLInputFactory.newFactory();
+        // Defend against XXE / "billion laughs": no DTDs, no external entity resolution.
+        f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return f;
+    }
+
+    /**
+     * Parses a {@code <Delete>} body into the keys to delete (and the {@code <Quiet>} flag). Throws
+     * {@link S3Exception} with {@link S3ErrorCode#MALFORMED_XML} if the body is not well-formed.
+     */
+    static DeleteRequest parseDelete(byte[] body) {
+        List<String> keys = new ArrayList<>();
+        boolean quiet = false;
+        XMLStreamReader reader = null;
+        try {
+            reader = INPUT_FACTORY.createXMLStreamReader(new ByteArrayInputStream(body));
+            while (reader.hasNext()) {
+                if (reader.next() != XMLStreamConstants.START_ELEMENT) {
+                    continue;
+                }
+                switch (reader.getLocalName()) {
+                    case "Key" -> keys.add(reader.getElementText());
+                    case "Quiet" -> quiet = Boolean.parseBoolean(reader.getElementText().trim());
+                    default -> { /* Delete, Object, and any unknown elements: descend/ignore. */ }
+                }
+            }
+            return new DeleteRequest(keys, quiet);
+        } catch (XMLStreamException e) {
+            throw new S3Exception(S3ErrorCode.MALFORMED_XML, "Malformed DeleteObjects body", e);
+        } finally {
+            closeQuietly(reader);
+        }
+    }
+
+    private static void closeQuietly(XMLStreamReader reader) {
+        if (reader != null) {
+            try {
+                reader.close();
+            } catch (XMLStreamException ignored) {
+                // best effort
+            }
+        }
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Router.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Router.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.util.Set;
+
+/**
+ * Pure routing: classifies a request from its method, the parsed {@code bucket}/{@code key}, and the
+ * set of query-parameter names into an {@link S3Action}. Path-style addressing only (the bucket is the
+ * first path segment; the {@code Host} header is irrelevant). PUT-vs-copy is decided later from the
+ * {@code x-amz-copy-source} header, so both classify as {@link S3Action#PUT_OBJECT} here.
+ *
+ * <p>Kept free of Netty types so it can be unit-tested directly. See {@code S3_GATEWAY_PLAN.md} §5.
+ */
+final class S3Router {
+
+    enum S3Action {
+        LIST_BUCKETS,
+        CREATE_BUCKET,
+        DELETE_BUCKET,
+        HEAD_BUCKET,
+        LIST_OBJECTS,
+        DELETE_OBJECTS,
+        GET_BUCKET_LOCATION,
+        GET_BUCKET_VERSIONING,
+        GET_BUCKET_ACL,
+        PUT_OBJECT,
+        GET_OBJECT,
+        HEAD_OBJECT,
+        DELETE_OBJECT,
+        UNSUPPORTED
+    }
+
+    private S3Router() {
+    }
+
+    /**
+     * @param method  the HTTP method name (upper-case: GET/PUT/HEAD/DELETE/POST)
+     * @param bucket  the parsed bucket, or {@code null} for the service root ("/")
+     * @param key     the parsed object key, or {@code null} if the request targets a bucket
+     * @param queries the set of query-parameter names present (lower-cased)
+     */
+    static S3Action route(String method, String bucket, String key, Set<String> queries) {
+        if (bucket == null) {
+            return "GET".equals(method) ? S3Action.LIST_BUCKETS : S3Action.UNSUPPORTED;
+        }
+        if (key == null || key.isEmpty()) {
+            return routeBucket(method, queries);
+        }
+        return switch (method) {
+            case "PUT" -> S3Action.PUT_OBJECT; // copy is decided from x-amz-copy-source later
+            case "GET" -> S3Action.GET_OBJECT;
+            case "HEAD" -> S3Action.HEAD_OBJECT;
+            case "DELETE" -> S3Action.DELETE_OBJECT;
+            default -> S3Action.UNSUPPORTED;
+        };
+    }
+
+    private static S3Action routeBucket(String method, Set<String> queries) {
+        return switch (method) {
+            case "PUT" -> S3Action.CREATE_BUCKET;
+            case "DELETE" -> S3Action.DELETE_BUCKET;
+            case "HEAD" -> S3Action.HEAD_BUCKET;
+            case "POST" -> queries.contains("delete") ? S3Action.DELETE_OBJECTS : S3Action.UNSUPPORTED;
+            case "GET" -> {
+                if (queries.contains("location")) {
+                    yield S3Action.GET_BUCKET_LOCATION;
+                }
+                if (queries.contains("versioning")) {
+                    yield S3Action.GET_BUCKET_VERSIONING;
+                }
+                if (queries.contains("acl")) {
+                    yield S3Action.GET_BUCKET_ACL;
+                }
+                yield S3Action.LIST_OBJECTS;
+            }
+            default -> S3Action.UNSUPPORTED;
+        };
+    }
+}

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Xml.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Xml.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.io.StringWriter;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * Renders the S3 XML response bodies the gateway returns, using the JDK StAX writer (so element text
+ * and attributes are escaped by the library, not by hand). The S3 namespace
+ * {@code http://s3.amazonaws.com/doc/2006-03-01/} is declared as the default namespace on the document
+ * roots that use it ({@code Error} and {@code CopyObjectResult} are unnamespaced, matching S3).
+ */
+final class S3Xml {
+
+    static final String NS = "http://s3.amazonaws.com/doc/2006-03-01/";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final String ANON_ID = "candybox";
+
+    private static final XMLOutputFactory OUTPUT_FACTORY = XMLOutputFactory.newFactory();
+    private static final DateTimeFormatter ISO8601 =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+    private S3Xml() {
+    }
+
+    /** An object row in a listing. {@code etag} may be {@code null} (the listing API returns no CRC32C). */
+    record Content(String key, long size, long lastModifiedMillis, String etag) {
+    }
+
+    static String error(S3ErrorCode error, String message, String resource, String requestId) {
+        return doc(w -> {
+            w.writeStartElement("Error");
+            el(w, "Code", error.code());
+            el(w, "Message", message == null ? error.defaultMessage() : message);
+            if (resource != null) {
+                el(w, "Resource", resource);
+            }
+            el(w, "RequestId", requestId);
+            w.writeEndElement();
+        });
+    }
+
+    static String listAllMyBuckets(List<String> buckets) {
+        String created = ISO8601.format(Instant.EPOCH);
+        return doc(w -> {
+            root(w, "ListAllMyBucketsResult");
+            w.writeStartElement("Owner");
+            el(w, "ID", ANON_ID);
+            el(w, "DisplayName", ANON_ID);
+            w.writeEndElement();
+            w.writeStartElement("Buckets");
+            for (String b : buckets) {
+                w.writeStartElement("Bucket");
+                el(w, "Name", b);
+                el(w, "CreationDate", created);
+                w.writeEndElement();
+            }
+            w.writeEndElement();
+            w.writeEndElement();
+        });
+    }
+
+    /** ListObjectsV2 result. {@code nextContinuationToken} non-null iff truncated. */
+    static String listBucket(String bucket, String prefix, String delimiter, int maxKeys,
+                             List<Content> contents, List<String> commonPrefixes,
+                             String continuationToken, String nextContinuationToken,
+                             String startAfter) {
+        return doc(w -> {
+            root(w, "ListBucketResult");
+            el(w, "Name", bucket);
+            el(w, "Prefix", prefix == null ? "" : prefix);
+            if (continuationToken != null) {
+                el(w, "ContinuationToken", continuationToken);
+            }
+            if (startAfter != null) {
+                el(w, "StartAfter", startAfter);
+            }
+            if (delimiter != null) {
+                el(w, "Delimiter", delimiter);
+            }
+            el(w, "KeyCount", Integer.toString(contents.size() + commonPrefixes.size()));
+            el(w, "MaxKeys", Integer.toString(maxKeys));
+            boolean truncated = nextContinuationToken != null;
+            el(w, "IsTruncated", Boolean.toString(truncated));
+            if (truncated) {
+                el(w, "NextContinuationToken", nextContinuationToken);
+            }
+            for (Content c : contents) {
+                w.writeStartElement("Contents");
+                el(w, "Key", c.key());
+                el(w, "LastModified", ISO8601.format(Instant.ofEpochMilli(c.lastModifiedMillis())));
+                if (c.etag() != null) {
+                    el(w, "ETag", '"' + c.etag() + '"');
+                }
+                el(w, "Size", Long.toString(c.size()));
+                el(w, "StorageClass", "STANDARD");
+                w.writeEndElement();
+            }
+            for (String cp : commonPrefixes) {
+                w.writeStartElement("CommonPrefixes");
+                el(w, "Prefix", cp);
+                w.writeEndElement();
+            }
+            w.writeEndElement();
+        });
+    }
+
+    static String copyObjectResult(String etag, long lastModifiedMillis) {
+        return doc(w -> {
+            w.writeStartElement("CopyObjectResult");
+            el(w, "LastModified", ISO8601.format(Instant.ofEpochMilli(lastModifiedMillis)));
+            el(w, "ETag", '"' + etag + '"');
+            w.writeEndElement();
+        });
+    }
+
+    /** Batch-delete result. {@code errors} entries are {@code [key, code, message]} triples. */
+    static String deleteResult(List<String> deletedKeys, List<String[]> errors) {
+        return doc(w -> {
+            root(w, "DeleteResult");
+            for (String key : deletedKeys) {
+                w.writeStartElement("Deleted");
+                el(w, "Key", key);
+                w.writeEndElement();
+            }
+            for (String[] e : errors) {
+                w.writeStartElement("Error");
+                el(w, "Key", e[0]);
+                el(w, "Code", e[1]);
+                el(w, "Message", e[2]);
+                w.writeEndElement();
+            }
+            w.writeEndElement();
+        });
+    }
+
+    static String locationConstraint(String region) {
+        // S3 returns an empty body for us-east-1; any other region as the element text.
+        String body = (region == null || region.equals("us-east-1")) ? "" : region;
+        return doc(w -> {
+            root(w, "LocationConstraint");
+            if (!body.isEmpty()) {
+                w.writeCharacters(body);
+            }
+            w.writeEndElement();
+        });
+    }
+
+    static String versioningConfiguration() {
+        return doc(w -> {
+            w.writeStartElement("VersioningConfiguration");
+            w.writeDefaultNamespace(NS);
+            w.writeEndElement();
+        });
+    }
+
+    static String accessControlPolicy() {
+        return doc(w -> {
+            root(w, "AccessControlPolicy");
+            w.writeStartElement("Owner");
+            el(w, "ID", ANON_ID);
+            el(w, "DisplayName", ANON_ID);
+            w.writeEndElement();
+            w.writeStartElement("AccessControlList");
+            w.writeStartElement("Grant");
+            w.writeStartElement("Grantee");
+            w.writeNamespace("xsi", XSI_NS);
+            w.writeAttribute(XSI_NS, "type", "CanonicalUser");
+            el(w, "ID", ANON_ID);
+            el(w, "DisplayName", ANON_ID);
+            w.writeEndElement();
+            el(w, "Permission", "FULL_CONTROL");
+            w.writeEndElement();
+            w.writeEndElement();
+            w.writeEndElement();
+        });
+    }
+
+    // ---- internals -------------------------------------------------------------------------
+
+    /** Opens a document root element in the S3 default namespace. */
+    private static void root(XMLStreamWriter w, String name) throws XMLStreamException {
+        w.writeStartElement(name);
+        w.writeDefaultNamespace(NS);
+    }
+
+    /** Writes {@code <name>text</name>}; the writer escapes the text. */
+    private static void el(XMLStreamWriter w, String name, String text) throws XMLStreamException {
+        w.writeStartElement(name);
+        if (text != null) {
+            w.writeCharacters(text);
+        }
+        w.writeEndElement();
+    }
+
+    @FunctionalInterface
+    private interface Body {
+        void write(XMLStreamWriter w) throws XMLStreamException;
+    }
+
+    private static String doc(Body body) {
+        StringWriter out = new StringWriter();
+        try {
+            XMLStreamWriter w = OUTPUT_FACTORY.createXMLStreamWriter(out);
+            w.writeStartDocument("UTF-8", "1.0");
+            body.write(w);
+            w.writeEndDocument();
+            w.flush();
+            w.close();
+        } catch (XMLStreamException e) {
+            // Generating our own fixed-shape documents should never fail.
+            throw new IllegalStateException("Failed to render S3 XML", e);
+        }
+        return out.toString();
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/AwsChunkedTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/AwsChunkedTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class AwsChunkedTest {
+
+    @Test
+    void detection() {
+        assertThat(AwsChunked.isChunked("aws-chunked", null)).isTrue();
+        assertThat(AwsChunked.isChunked(null, "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")).isTrue();
+        assertThat(AwsChunked.isChunked(null, "UNSIGNED-PAYLOAD")).isFalse();
+        assertThat(AwsChunked.isChunked(null, null)).isFalse();
+    }
+
+    @Test
+    void decodesSignedChunks() {
+        String framed = "5;chunk-signature=abc123\r\nhello\r\n0;chunk-signature=def456\r\n\r\n";
+        byte[] out = AwsChunked.decode(framed.getBytes(StandardCharsets.UTF_8), 5);
+        assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("hello");
+    }
+
+    @Test
+    void decodesUnsignedChunksAcrossMultipleChunks() {
+        String framed = "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n";
+        byte[] out = AwsChunked.decode(framed.getBytes(StandardCharsets.UTF_8), 6);
+        assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("foobar");
+    }
+
+    @Test
+    void terminatorOnlyBodyDecodesToEmpty() {
+        byte[] out = AwsChunked.decode("0\r\n\r\n".getBytes(StandardCharsets.UTF_8), 0);
+        assertThat(out).isEmpty();
+        assertThat(AwsChunked.decode(new byte[0], -1)).isEmpty();
+    }
+
+    @Test
+    void toleratesMissingCrlfBeforeTerminator() {
+        // Data chunk not followed by the optional CRLF, then the 0-terminator.
+        byte[] out = AwsChunked.decode("3\r\nfoo0\r\n\r\n".getBytes(StandardCharsets.UTF_8), 3);
+        assertThat(new String(out, StandardCharsets.UTF_8)).isEqualTo("foo");
+    }
+
+    @Test
+    void rejectsTruncatedChunk() {
+        String framed = "10\r\nonly-a-few\r\n"; // declares 16 bytes, far fewer present
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> AwsChunked.decode(framed.getBytes(StandardCharsets.UTF_8), -1))
+                .isInstanceOf(S3Exception.class);
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/ErrorMapperTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/ErrorMapperTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import me.predatorray.candybox.common.exception.BoxAlreadyExistsException;
+import me.predatorray.candybox.common.exception.BoxNotEmptyException;
+import me.predatorray.candybox.common.exception.BoxNotFoundException;
+import me.predatorray.candybox.common.exception.BusyException;
+import me.predatorray.candybox.common.exception.CandyNotFoundException;
+import me.predatorray.candybox.common.exception.CandyboxException;
+import me.predatorray.candybox.common.exception.FencedException;
+import me.predatorray.candybox.common.exception.LimitExceededException;
+import me.predatorray.candybox.common.exception.NotOwnerException;
+import me.predatorray.candybox.common.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+class ErrorMapperTest {
+
+    @Test
+    void concreteTypes() {
+        assertThat(ErrorMapper.toS3(new CandyNotFoundException("b", "k")).error())
+                .isEqualTo(S3ErrorCode.NO_SUCH_KEY);
+        assertThat(ErrorMapper.toS3(new BoxAlreadyExistsException("b")).error())
+                .isEqualTo(S3ErrorCode.BUCKET_ALREADY_OWNED_BY_YOU);
+        assertThat(ErrorMapper.toS3(new BusyException("busy")).error())
+                .isEqualTo(S3ErrorCode.SLOW_DOWN);
+        assertThat(ErrorMapper.toS3(new NotOwnerException("b")).error())
+                .isEqualTo(S3ErrorCode.SERVICE_UNAVAILABLE);
+        assertThat(ErrorMapper.toS3(new FencedException("fenced")).error())
+                .isEqualTo(S3ErrorCode.SERVICE_UNAVAILABLE);
+        assertThat(ErrorMapper.toS3(new BoxNotFoundException("b")).error())
+                .isEqualTo(S3ErrorCode.NO_SUCH_BUCKET);
+        assertThat(ErrorMapper.toS3(new BoxNotEmptyException("b")).error())
+                .isEqualTo(S3ErrorCode.BUCKET_NOT_EMPTY);
+    }
+
+    @Test
+    void serviceUnavailableIsRetryable() {
+        assertThat(ErrorMapper.toS3(new NotOwnerException("b")).error().retryable()).isTrue();
+        assertThat(ErrorMapper.toS3(new BusyException("x")).error().retryable()).isTrue();
+        assertThat(ErrorMapper.toS3(new CandyNotFoundException("b", "k")).error().retryable()).isFalse();
+    }
+
+    @Test
+    void validationDistinguishesBucketName() {
+        assertThat(ErrorMapper.toS3(new ValidationException("Box name must match ...")).error())
+                .isEqualTo(S3ErrorCode.INVALID_BUCKET_NAME);
+        assertThat(ErrorMapper.toS3(new ValidationException("something else")).error())
+                .isEqualTo(S3ErrorCode.INVALID_ARGUMENT);
+    }
+
+    @Test
+    void limitExceededDistinguishesKeyVsSize() {
+        assertThat(ErrorMapper.toS3(new LimitExceededException("CandyKey too long")).error())
+                .isEqualTo(S3ErrorCode.KEY_TOO_LONG);
+        assertThat(ErrorMapper.toS3(new LimitExceededException("Candy size exceeds limit")).error())
+                .isEqualTo(S3ErrorCode.ENTITY_TOO_LARGE);
+    }
+
+    @Test
+    void genericClientWrappedMessages() {
+        // The client collapses server errors into a generic CandyboxException prefixed with the type.
+        assertThat(ErrorMapper.toS3(new CandyboxException("BoxNotEmptyException: not empty")).error())
+                .isEqualTo(S3ErrorCode.BUCKET_NOT_EMPTY);
+        assertThat(ErrorMapper.toS3(new CandyboxException("BoxAlreadyExistsException: exists")).error())
+                .isEqualTo(S3ErrorCode.BUCKET_ALREADY_OWNED_BY_YOU);
+        assertThat(ErrorMapper.toS3(new CandyboxException("Not found")).error())
+                .isEqualTo(S3ErrorCode.NO_SUCH_KEY);
+        assertThat(ErrorMapper.toS3(new CandyboxException("UnsupportedOperation: nope")).error())
+                .isEqualTo(S3ErrorCode.NOT_IMPLEMENTED);
+    }
+
+    @Test
+    void unknownFallsBackToInternalError() {
+        assertThat(ErrorMapper.toS3(new IllegalStateException("boom")).error())
+                .isEqualTo(S3ErrorCode.INTERNAL_ERROR);
+        assertThat(ErrorMapper.toS3(new CandyboxException("WeirdThing: huh")).error())
+                .isEqualTo(S3ErrorCode.INTERNAL_ERROR);
+    }
+
+    @Test
+    void s3ExceptionPassesThrough() {
+        S3Exception original = new S3Exception(S3ErrorCode.MALFORMED_XML, "bad");
+        assertThat(ErrorMapper.toS3(original)).isSameAs(original);
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/EtagTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/EtagTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EtagTest {
+
+    @Test
+    void formatsAsQuoted32HexFromCrc32c() {
+        // Left-padded to 32 hex chars so it has the visual shape of an MD5 ETag.
+        assertThat(Etag.of(0x8f3a2b1c)).isEqualTo("\"0000000000000000000000008f3a2b1c\"");
+        assertThat(Etag.unquoted(0x8f3a2b1c)).isEqualTo("0000000000000000000000008f3a2b1c");
+        assertThat(Etag.unquoted(0x8f3a2b1c)).hasSize(32);
+    }
+
+    @Test
+    void treatsCrcAsUnsigned32Bit() {
+        // 0xffffffff must not become a negative/sign-extended value.
+        assertThat(Etag.unquoted(0xffffffff)).isEqualTo("000000000000000000000000ffffffff");
+        assertThat(Etag.unquoted(0)).isEqualTo("00000000000000000000000000000000");
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/FakeCandyStore.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/FakeCandyStore.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import me.predatorray.candybox.client.CandyboxClient.CandyInfo;
+import me.predatorray.candybox.client.CandyboxClient.Listing;
+import me.predatorray.candybox.common.checksum.Crc32c;
+import me.predatorray.candybox.common.exception.BoxAlreadyExistsException;
+import me.predatorray.candybox.common.exception.BoxNotEmptyException;
+import me.predatorray.candybox.common.exception.BoxNotFoundException;
+import me.predatorray.candybox.common.exception.CandyNotFoundException;
+
+/**
+ * A hand-written in-memory {@link CandyStore} for unit tests — no sockets, no BookKeeper. Models the
+ * Box/Candy semantics and the failure modes the gateway must translate (missing box/key, box exists,
+ * box not empty). Keys are kept sorted per Box so listing/pagination behave like the real engine.
+ */
+final class FakeCandyStore implements CandyStore {
+
+    private record Obj(byte[] data, String contentType, Map<String, String> meta, int crc32c, long created) {
+    }
+
+    private final Map<String, TreeMap<String, Obj>> boxes = new LinkedHashMap<>();
+
+    @Override
+    public void createBox(String box) {
+        if (boxes.containsKey(box)) {
+            throw new BoxAlreadyExistsException(box);
+        }
+        boxes.put(box, new TreeMap<>());
+    }
+
+    @Override
+    public void deleteBox(String box) {
+        TreeMap<String, Obj> b = boxes.get(box);
+        if (b == null) {
+            throw new BoxNotFoundException(box);
+        }
+        if (!b.isEmpty()) {
+            throw new BoxNotEmptyException(box);
+        }
+        boxes.remove(box);
+    }
+
+    @Override
+    public boolean headBox(String box) {
+        return boxes.containsKey(box);
+    }
+
+    @Override
+    public List<String> listBoxes() {
+        return new ArrayList<>(boxes.keySet());
+    }
+
+    @Override
+    public void putCandy(String box, String key, byte[] data, String contentType,
+                         Map<String, String> userMetadata) {
+        box(box).put(key, new Obj(data.clone(), contentType,
+                userMetadata == null ? Map.of() : new LinkedHashMap<>(userMetadata),
+                Crc32c.of(data), System.currentTimeMillis()));
+    }
+
+    @Override
+    public byte[] getCandy(String box, String key) {
+        return obj(box, key).data().clone();
+    }
+
+    @Override
+    public CandyInfo headCandy(String box, String key) {
+        Obj o = obj(box, key);
+        return new CandyInfo(o.data().length, o.contentType(), o.meta(), o.crc32c(), o.created());
+    }
+
+    @Override
+    public void deleteCandy(String box, String key) {
+        TreeMap<String, Obj> b = box(box);
+        if (b.remove(key) == null) {
+            throw new CandyNotFoundException(box, key);
+        }
+    }
+
+    @Override
+    public CandyInfo copyCandy(String box, String srcKey, String dstKey) {
+        Obj src = obj(box, srcKey);
+        box(box).put(dstKey, new Obj(src.data(), src.contentType(), src.meta(), src.crc32c(),
+                System.currentTimeMillis()));
+        return headCandy(box, dstKey);
+    }
+
+    @Override
+    public Listing listCandies(String box, String prefix, String startAfter, int maxKeys) {
+        TreeMap<String, Obj> b = box(box);
+        List<Listing.Entry> entries = new ArrayList<>();
+        String next = null;
+        for (Map.Entry<String, Obj> e : b.entrySet()) {
+            String key = e.getKey();
+            if (prefix != null && !prefix.isEmpty() && !key.startsWith(prefix)) {
+                continue;
+            }
+            if (startAfter != null && key.compareTo(startAfter) <= 0) {
+                continue;
+            }
+            if (entries.size() == maxKeys) {
+                next = entries.get(entries.size() - 1).key();
+                break;
+            }
+            entries.add(new Listing.Entry(key, e.getValue().data().length, e.getValue().created()));
+        }
+        return new Listing(entries, next);
+    }
+
+    private TreeMap<String, Obj> box(String box) {
+        TreeMap<String, Obj> b = boxes.get(box);
+        if (b == null) {
+            throw new BoxNotFoundException(box);
+        }
+        return b;
+    }
+
+    private Obj obj(String box, String key) {
+        Obj o = box(box).get(key);
+        if (o == null) {
+            throw new CandyNotFoundException(box, key);
+        }
+        return o;
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/GatewayHealthServerTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/GatewayHealthServerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class GatewayHealthServerTest {
+
+    @Test
+    void healthAndReadinessAndMetrics() throws Exception {
+        AtomicBoolean ready = new AtomicBoolean(true);
+        GatewayHealthServer health = new GatewayHealthServer(0, ready::get);
+        health.start();
+        try {
+            HttpClient http = HttpClient.newHttpClient();
+            String base = "http://127.0.0.1:" + health.port();
+
+            assertThat(get(http, base + "/healthz").statusCode()).isEqualTo(200);
+
+            assertThat(get(http, base + "/readyz").statusCode()).isEqualTo(200);
+            ready.set(false);
+            assertThat(get(http, base + "/readyz").statusCode()).isEqualTo(503);
+
+            var metrics = get(http, base + "/metrics");
+            assertThat(metrics.statusCode()).isEqualTo(200);
+            assertThat(metrics.body()).contains("candybox_s3_gateway_up");
+        } finally {
+            health.close();
+        }
+    }
+
+    private static java.net.http.HttpResponse<String> get(HttpClient http, String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), BodyHandlers.ofString());
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3GatewayConfigTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3GatewayConfigTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class S3GatewayConfigTest {
+
+    private static Properties props(String... kv) {
+        Properties p = new Properties();
+        for (int i = 0; i + 1 < kv.length; i += 2) {
+            p.setProperty(kv[i], kv[i + 1]);
+        }
+        return p;
+    }
+
+    @Test
+    void appliesDefaultsWhenOnlyTheRequiredKeyIsSet() {
+        S3GatewayConfig c = S3GatewayConfig.fromProperties(props("zookeeper.connect", "zk:2181"), Map.of());
+        assertThat(c.bindHost()).isEqualTo("0.0.0.0");
+        assertThat(c.bindPort()).isEqualTo(S3GatewayConfig.DEFAULT_PORT);
+        assertThat(c.healthPort()).isEqualTo(S3GatewayConfig.DEFAULT_HEALTH_PORT);
+        assertThat(c.region()).isEqualTo("us-east-1");
+        assertThat(c.maxObjectBytes()).isEqualTo(S3GatewayConfig.DEFAULT_MAX_OBJECT_BYTES);
+        assertThat(c.routerCacheTtlMillis()).isEqualTo(5_000L);
+        assertThat(c.workerThreads()).isGreaterThanOrEqualTo(4);
+        assertThat(c.zookeeperConnect()).isEqualTo("zk:2181");
+    }
+
+    @Test
+    void parsesAllFileKeys() {
+        S3GatewayConfig c = S3GatewayConfig.fromProperties(props(
+                "zookeeper.connect", "zk:2181",
+                "s3.bind", "10.0.0.1:8080",
+                "health.port", "8081",
+                "s3.region", "eu-west-1",
+                "s3.max-object-bytes", "1048576",
+                "s3.worker-threads", "16",
+                "s3.router-cache-ttl-ms", "250"), Map.of());
+        assertThat(c.bindHost()).isEqualTo("10.0.0.1");
+        assertThat(c.bindPort()).isEqualTo(8080);
+        assertThat(c.healthPort()).isEqualTo(8081);
+        assertThat(c.region()).isEqualTo("eu-west-1");
+        assertThat(c.maxObjectBytes()).isEqualTo(1_048_576L);
+        assertThat(c.workerThreads()).isEqualTo(16);
+        assertThat(c.routerCacheTtlMillis()).isEqualTo(250L);
+    }
+
+    @Test
+    void environmentOverridesFileAndNormalizesDashesAndDots() {
+        Properties file = props("zookeeper.connect", "file-zk:2181", "s3.region", "ap-south-1");
+        Map<String, String> env = Map.of(
+                "CANDYBOX_ZOOKEEPER_CONNECT", "env-zk:2181",
+                "CANDYBOX_S3_BIND", "127.0.0.1:9999",
+                "CANDYBOX_S3_MAX_OBJECT_BYTES", "42"); // dashes in key -> underscores in env name
+        S3GatewayConfig c = S3GatewayConfig.fromProperties(file, env);
+        assertThat(c.zookeeperConnect()).isEqualTo("env-zk:2181"); // env wins over file
+        assertThat(c.region()).isEqualTo("ap-south-1");            // file value retained
+        assertThat(c.bindPort()).isEqualTo(9999);
+        assertThat(c.maxObjectBytes()).isEqualTo(42L);
+    }
+
+    @Test
+    void bindWithoutPortFallsBackToDefaultPort() {
+        S3GatewayConfig c = S3GatewayConfig.fromProperties(
+                props("zookeeper.connect", "zk:2181", "s3.bind", "myhost"), Map.of());
+        assertThat(c.bindHost()).isEqualTo("myhost");
+        assertThat(c.bindPort()).isEqualTo(S3GatewayConfig.DEFAULT_PORT);
+    }
+
+    @Test
+    void blankValuesAreIgnoredAndFallBackToDefaults() {
+        S3GatewayConfig c = S3GatewayConfig.fromProperties(
+                props("zookeeper.connect", "zk:2181", "s3.region", "  "), Map.of());
+        assertThat(c.region()).isEqualTo("us-east-1");
+    }
+
+    @Test
+    void missingZookeeperConnectIsRejected() {
+        assertThatThrownBy(() -> S3GatewayConfig.fromProperties(new Properties(), Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("zookeeper.connect");
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3GatewayServerTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3GatewayServerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the real Netty {@link S3GatewayServer} over a loopback socket with an in-memory
+ * {@link FakeCandyStore}. Unlike {@link S3HandlerTest} (which feeds the handler via EmbeddedChannel),
+ * this exercises the full pipeline — {@code HttpServerCodec} + {@code HttpObjectAggregator} + the
+ * blocking handler — so it covers HTTP framing, keep-alive, aws-chunked uploads, and percent-decoded
+ * keys end to end without BookKeeper/ZooKeeper.
+ */
+class S3GatewayServerTest {
+
+    private static S3GatewayServer server;
+    private static HttpClient http;
+    private static String baseUri;
+
+    @BeforeAll
+    static void start() {
+        Properties props = new Properties();
+        props.setProperty("zookeeper.connect", "unused:2181");
+        props.setProperty("s3.bind", "127.0.0.1:0");
+        server = new S3GatewayServer(S3GatewayConfig.fromProperties(props, java.util.Map.of()),
+                new FakeCandyStore());
+        server.start();
+        http = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        baseUri = "http://127.0.0.1:" + server.port();
+    }
+
+    @AfterAll
+    static void stop() {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    @Test
+    void putGetOverRealSocketDefaultsContentType() throws Exception {
+        assertThat(send("PUT", "/photos", null).statusCode()).isEqualTo(200);
+        byte[] data = "real socket bytes".getBytes(StandardCharsets.UTF_8);
+        assertThat(send("PUT", "/photos/obj.bin", data).statusCode()).isEqualTo(200);
+
+        HttpResponse<byte[]> get = http.send(
+                HttpRequest.newBuilder(URI.create(baseUri + "/photos/obj.bin")).GET().build(),
+                BodyHandlers.ofByteArray());
+        assertThat(get.statusCode()).isEqualTo(200);
+        assertThat(get.body()).isEqualTo(data);
+        // No Content-Type was sent on PUT, so the gateway defaults it.
+        assertThat(get.headers().firstValue("Content-Type")).hasValue("application/octet-stream");
+    }
+
+    @Test
+    void decodesAwsChunkedUploads() throws Exception {
+        send("PUT", "/chunked", null);
+        // "hello candybox" is 14 (0xe) bytes, wrapped as one signed chunk + the terminating chunk.
+        String framed = "e;chunk-signature=deadbeef\r\nhello candybox\r\n0;chunk-signature=cafe\r\n\r\n";
+        HttpRequest put = HttpRequest.newBuilder(URI.create(baseUri + "/chunked/obj"))
+                .header("Content-Encoding", "aws-chunked")
+                .header("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+                .header("x-amz-decoded-content-length", "14")
+                .PUT(BodyPublishers.ofString(framed))
+                .build();
+        assertThat(http.send(put, BodyHandlers.ofString()).statusCode()).isEqualTo(200);
+
+        HttpResponse<String> get = http.send(
+                HttpRequest.newBuilder(URI.create(baseUri + "/chunked/obj")).GET().build(),
+                BodyHandlers.ofString());
+        assertThat(get.body()).isEqualTo("hello candybox"); // framing stripped, not stored verbatim
+    }
+
+    @Test
+    void percentEncodedKeysAreDecoded() throws Exception {
+        send("PUT", "/docs", null);
+        assertThat(send("PUT", "/docs/a%20b%2Bc.txt", "x".getBytes(StandardCharsets.UTF_8)).statusCode())
+                .isEqualTo(200);
+        // The stored key is the decoded form; listing shows it and a HEAD on the encoded path resolves.
+        assertThat(send("GET", "/docs?list-type=2", null).body()).contains("<Key>a b+c.txt</Key>");
+        assertThat(send("HEAD", "/docs/a%20b%2Bc.txt", null).statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void missingKeyReturns404() throws Exception {
+        send("PUT", "/empty", null);
+        HttpResponse<String> r = send("GET", "/empty/nope", null);
+        assertThat(r.statusCode()).isEqualTo(404);
+        assertThat(r.body()).contains("<Code>NoSuchKey</Code>");
+        assertThat(r.headers().firstValue("x-amz-request-id")).isPresent();
+    }
+
+    private HttpResponse<String> send(String method, String path, byte[] body) throws Exception {
+        HttpRequest req = HttpRequest.newBuilder(URI.create(baseUri + path))
+                .method(method, body == null ? BodyPublishers.noBody() : BodyPublishers.ofByteArray(body))
+                .build();
+        return http.send(req, BodyHandlers.ofString());
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3HandlerTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3HandlerTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.function.Consumer;
+import me.predatorray.candybox.common.checksum.Crc32c;
+import org.junit.jupiter.api.Test;
+
+class S3HandlerTest {
+
+    private final FakeCandyStore store = new FakeCandyStore();
+
+    // ---- buckets ---------------------------------------------------------------------------
+
+    @Test
+    void createHeadAndListBuckets() {
+        assertThat(put("/photos").status).isEqualTo(200);
+        assertThat(head("/photos").status).isEqualTo(200);
+        assertThat(head("/missing").status).isEqualTo(404);
+
+        Response list = get("/");
+        assertThat(list.status).isEqualTo(200);
+        assertThat(list.body).contains("<Name>photos</Name>");
+    }
+
+    @Test
+    void createDuplicateBucketReturns409() {
+        put("/photos");
+        assertThat(put("/photos").status).isEqualTo(409);
+    }
+
+    @Test
+    void deleteNonEmptyBucketReturns409() {
+        put("/photos");
+        put("/photos/cat.txt", "hi".getBytes(StandardCharsets.UTF_8), null);
+        Response r = delete("/photos");
+        assertThat(r.status).isEqualTo(409);
+        assertThat(r.body).contains("<Code>BucketNotEmpty</Code>");
+    }
+
+    // ---- objects ---------------------------------------------------------------------------
+
+    @Test
+    void putGetRoundTripWithDeterministicEtag() {
+        put("/photos");
+        byte[] data = "hello candybox".getBytes(StandardCharsets.UTF_8);
+        Response p = put("/photos/hello.txt", data, h -> h.set(HttpHeaderNames.CONTENT_TYPE, "text/plain"));
+        assertThat(p.status).isEqualTo(200);
+        String expectedEtag = Etag.of(Crc32c.of(data));
+        assertThat(p.etag()).isEqualTo(expectedEtag);
+
+        Response g = get("/photos/hello.txt");
+        assertThat(g.status).isEqualTo(200);
+        assertThat(g.body).isEqualTo("hello candybox");
+        assertThat(g.header(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/plain");
+        assertThat(g.etag()).isEqualTo(expectedEtag);
+    }
+
+    @Test
+    void userMetadataRoundTrips() {
+        put("/photos");
+        put("/photos/cat.txt", "x".getBytes(StandardCharsets.UTF_8),
+                h -> h.set("x-amz-meta-Owner", "alice"));
+        Response h = head("/photos/cat.txt");
+        assertThat(h.status).isEqualTo(200);
+        assertThat(h.header("x-amz-meta-owner")).isEqualTo("alice");
+        assertThat(h.header(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("1");
+    }
+
+    @Test
+    void getMissingKeyReturns404NoSuchKey() {
+        put("/photos");
+        Response r = get("/photos/nope.txt");
+        assertThat(r.status).isEqualTo(404);
+        assertThat(r.body).contains("<Code>NoSuchKey</Code>");
+    }
+
+    @Test
+    void deleteIsIdempotent() {
+        put("/photos");
+        assertThat(delete("/photos/never.txt").status).isEqualTo(204);
+    }
+
+    @Test
+    void copyObjectSameBucket() {
+        put("/photos");
+        put("/photos/cat.txt", "meow".getBytes(StandardCharsets.UTF_8), null);
+        Response c = put("/photos/copy.txt", new byte[0],
+                h -> h.set("x-amz-copy-source", "/photos/cat.txt"));
+        assertThat(c.status).isEqualTo(200);
+        assertThat(c.body).contains("<CopyObjectResult>");
+        assertThat(get("/photos/copy.txt").body).isEqualTo("meow");
+    }
+
+    @Test
+    void crossBucketCopyNotImplemented() {
+        put("/photos");
+        put("/other");
+        Response c = put("/photos/copy.txt", new byte[0],
+                h -> h.set("x-amz-copy-source", "/other/cat.txt"));
+        assertThat(c.status).isEqualTo(501);
+    }
+
+    // ---- listing ---------------------------------------------------------------------------
+
+    @Test
+    void listObjectsWithDelimiterRollsUpCommonPrefixes() {
+        put("/photos");
+        put("/photos/a/x.txt", "1".getBytes(StandardCharsets.UTF_8), null);
+        put("/photos/a/sub/y.txt", "2".getBytes(StandardCharsets.UTF_8), null);
+        Response r = get("/photos?prefix=a/&delimiter=/");
+        assertThat(r.status).isEqualTo(200);
+        assertThat(r.body).contains("<Key>a/x.txt</Key>")
+                .contains("<Prefix>a/sub/</Prefix>")
+                .doesNotContain("<Key>a/sub/y.txt</Key>");
+    }
+
+    @Test
+    void listObjectsPaginatesWithContinuationToken() {
+        put("/photos");
+        for (String k : new String[]{"k1", "k2", "k3"}) {
+            put("/photos/" + k, "v".getBytes(StandardCharsets.UTF_8), null);
+        }
+        Response first = get("/photos?list-type=2&max-keys=2");
+        assertThat(first.body).contains("<IsTruncated>true</IsTruncated>")
+                .contains("<NextContinuationToken>");
+        String token = between(first.body, "<NextContinuationToken>", "</NextContinuationToken>");
+
+        Response second = get("/photos?list-type=2&max-keys=2&continuation-token=" + token);
+        assertThat(second.body).contains("<Key>k3</Key>")
+                .contains("<IsTruncated>false</IsTruncated>");
+    }
+
+    @Test
+    void batchDeleteObjects() {
+        put("/photos");
+        put("/photos/a.txt", "1".getBytes(StandardCharsets.UTF_8), null);
+        put("/photos/b.txt", "2".getBytes(StandardCharsets.UTF_8), null);
+        String body = "<Delete><Object><Key>a.txt</Key></Object>"
+                + "<Object><Key>b.txt</Key></Object></Delete>";
+        Response r = exchange(HttpMethod.POST, "/photos?delete",
+                body.getBytes(StandardCharsets.UTF_8), null);
+        assertThat(r.status).isEqualTo(200);
+        assertThat(r.body).contains("<Deleted><Key>a.txt</Key></Deleted>")
+                .contains("<Deleted><Key>b.txt</Key></Deleted>");
+        assertThat(get("/photos/a.txt").status).isEqualTo(404);
+    }
+
+    @Test
+    void batchDeleteQuietModeOmitsSuccesses() {
+        put("/photos");
+        put("/photos/a.txt", "1".getBytes(StandardCharsets.UTF_8), null);
+        String body = "<Delete><Quiet>true</Quiet><Object><Key>a.txt</Key></Object></Delete>";
+        Response r = exchange(HttpMethod.POST, "/photos?delete",
+                body.getBytes(StandardCharsets.UTF_8), null);
+        assertThat(r.status).isEqualTo(200);
+        assertThat(r.body).contains("<DeleteResult").doesNotContain("<Deleted>");
+    }
+
+    // ---- subresources & unsupported --------------------------------------------------------
+
+    @Test
+    void cannedSubresources() {
+        put("/photos");
+        assertThat(get("/photos?location").body).contains("LocationConstraint");
+        assertThat(get("/photos?versioning").body).contains("VersioningConfiguration");
+        assertThat(get("/photos?acl").body).contains("AccessControlPolicy");
+    }
+
+    @Test
+    void unsupportedMethodReturns501() {
+        Response r = exchange(HttpMethod.PATCH, "/photos/x", new byte[0], null);
+        assertThat(r.status).isEqualTo(501);
+    }
+
+    @Test
+    void everyResponseCarriesRequestId() {
+        assertThat(get("/").header("x-amz-request-id")).isNotBlank();
+    }
+
+    @Test
+    void listBucketsWhenEmpty() {
+        Response r = get("/");
+        assertThat(r.status).isEqualTo(200);
+        assertThat(r.body).contains("<ListAllMyBucketsResult").doesNotContain("<Name>");
+    }
+
+    @Test
+    void putExceedingMaxObjectBytesReturns400() {
+        put("/photos");
+        Properties p = new Properties();
+        p.setProperty("zookeeper.connect", "unused:2181");
+        p.setProperty("s3.max-object-bytes", "4");
+        S3GatewayConfig tiny = S3GatewayConfig.fromProperties(p, java.util.Map.of());
+        EmbeddedChannel ch = new EmbeddedChannel(new S3Handler(store, tiny));
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
+                "/photos/big.bin", Unpooled.wrappedBuffer("too many bytes".getBytes(StandardCharsets.UTF_8)));
+        ch.writeInbound(req);
+        Response r = Response.capture(ch.readOutbound());
+        ch.finishAndReleaseAll();
+        assertThat(r.status).isEqualTo(400);
+        assertThat(r.body).contains("<Code>EntityTooLarge</Code>");
+    }
+
+    @Test
+    void malformedCopySourceReturns400() {
+        put("/photos");
+        Response r = put("/photos/dst.txt", new byte[0], h -> h.set("x-amz-copy-source", "no-slash-here"));
+        assertThat(r.status).isEqualTo(400);
+        assertThat(r.body).contains("<Code>InvalidArgument</Code>");
+    }
+
+    @Test
+    void putWithoutContentTypeDefaultsToOctetStream() {
+        put("/photos");
+        put("/photos/blob", "x".getBytes(StandardCharsets.UTF_8), null);
+        assertThat(head("/photos/blob").header(HttpHeaderNames.CONTENT_TYPE))
+                .isEqualTo("application/octet-stream");
+    }
+
+    // ---- harness ---------------------------------------------------------------------------
+
+    private static S3GatewayConfig config() {
+        Properties p = new Properties();
+        p.setProperty("zookeeper.connect", "unused:2181");
+        return S3GatewayConfig.fromProperties(p, java.util.Map.of());
+    }
+
+    private Response get(String uri) {
+        return exchange(HttpMethod.GET, uri, null, null);
+    }
+
+    private Response head(String uri) {
+        return exchange(HttpMethod.HEAD, uri, null, null);
+    }
+
+    private Response delete(String uri) {
+        return exchange(HttpMethod.DELETE, uri, null, null);
+    }
+
+    private Response put(String uri) {
+        return exchange(HttpMethod.PUT, uri, new byte[0], null);
+    }
+
+    private Response put(String uri, byte[] body, Consumer<HttpHeaders> headers) {
+        return exchange(HttpMethod.PUT, uri, body, headers);
+    }
+
+    private Response exchange(HttpMethod method, String uri, byte[] body, Consumer<HttpHeaders> headers) {
+        EmbeddedChannel channel = new EmbeddedChannel(new S3Handler(store, config()));
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uri,
+                body == null ? Unpooled.EMPTY_BUFFER : Unpooled.wrappedBuffer(body));
+        if (headers != null) {
+            headers.accept(request.headers());
+        }
+        channel.writeInbound(request);
+        FullHttpResponse response = channel.readOutbound();
+        Response captured = Response.capture(response);
+        channel.finishAndReleaseAll();
+        return captured;
+    }
+
+    private static String between(String s, String start, String end) {
+        int a = s.indexOf(start) + start.length();
+        return s.substring(a, s.indexOf(end, a));
+    }
+
+    private static final class Response {
+        final int status;
+        final String body;
+        private final HttpHeaders headers;
+
+        private Response(int status, String body, HttpHeaders headers) {
+            this.status = status;
+            this.body = body;
+            this.headers = headers;
+        }
+
+        static Response capture(FullHttpResponse r) {
+            String body = r.content().toString(StandardCharsets.UTF_8);
+            HttpHeaders headers = r.headers().copy();
+            int status = r.status().code();
+            r.release();
+            return new Response(status, body, headers);
+        }
+
+        String header(CharSequence name) {
+            return headers.get(name);
+        }
+
+        String etag() {
+            return headers.get(HttpHeaderNames.ETAG);
+        }
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RequestXmlTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RequestXmlTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class S3RequestXmlTest {
+
+    private static S3RequestXml.DeleteRequest parse(String xml) {
+        return S3RequestXml.parseDelete(xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void parsesKeysAndDefaultsToNonQuiet() {
+        S3RequestXml.DeleteRequest r = parse(
+                "<Delete><Object><Key>a.txt</Key></Object>"
+                        + "<Object><Key>b/c.txt</Key></Object></Delete>");
+        assertThat(r.keys()).containsExactly("a.txt", "b/c.txt");
+        assertThat(r.quiet()).isFalse();
+    }
+
+    @Test
+    void unescapesEntitiesInKeys() {
+        S3RequestXml.DeleteRequest r = parse(
+                "<Delete><Object><Key>a &amp; b &lt;c&gt;.txt</Key></Object></Delete>");
+        assertThat(r.keys()).containsExactly("a & b <c>.txt");
+    }
+
+    @Test
+    void readsQuietFlag() {
+        S3RequestXml.DeleteRequest r = parse(
+                "<Delete><Quiet>true</Quiet><Object><Key>k</Key></Object></Delete>");
+        assertThat(r.quiet()).isTrue();
+        assertThat(r.keys()).containsExactly("k");
+    }
+
+    @Test
+    void malformedBodyIsRejected() {
+        assertThatThrownBy(() -> parse("<Delete><Object>"))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.error()).isEqualTo(S3ErrorCode.MALFORMED_XML));
+    }
+
+    @Test
+    void rejectsDtdSoExternalEntitiesCannotExpand() {
+        // A DOCTYPE/XXE attempt: with DTDs disabled the parser must refuse rather than resolve the
+        // external entity.
+        String xxe = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE Delete [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+                + "<Delete><Object><Key>&xxe;</Key></Object></Delete>";
+        assertThatThrownBy(() -> parse(xxe))
+                .isInstanceOfSatisfying(S3Exception.class,
+                        e -> assertThat(e.error()).isEqualTo(S3ErrorCode.MALFORMED_XML));
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RouterTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RouterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import me.predatorray.candybox.s3.S3Router.S3Action;
+import org.junit.jupiter.api.Test;
+
+class S3RouterTest {
+
+    @Test
+    void serviceRoot() {
+        assertThat(S3Router.route("GET", null, null, Set.of())).isEqualTo(S3Action.LIST_BUCKETS);
+        assertThat(S3Router.route("POST", null, null, Set.of())).isEqualTo(S3Action.UNSUPPORTED);
+    }
+
+    @Test
+    void bucketOps() {
+        assertThat(S3Router.route("PUT", "photos", null, Set.of())).isEqualTo(S3Action.CREATE_BUCKET);
+        assertThat(S3Router.route("DELETE", "photos", "", Set.of())).isEqualTo(S3Action.DELETE_BUCKET);
+        assertThat(S3Router.route("HEAD", "photos", null, Set.of())).isEqualTo(S3Action.HEAD_BUCKET);
+        assertThat(S3Router.route("GET", "photos", null, Set.of())).isEqualTo(S3Action.LIST_OBJECTS);
+        assertThat(S3Router.route("POST", "photos", null, Set.of("delete")))
+                .isEqualTo(S3Action.DELETE_OBJECTS);
+    }
+
+    @Test
+    void bucketSubresources() {
+        assertThat(S3Router.route("GET", "photos", null, Set.of("location")))
+                .isEqualTo(S3Action.GET_BUCKET_LOCATION);
+        assertThat(S3Router.route("GET", "photos", null, Set.of("versioning")))
+                .isEqualTo(S3Action.GET_BUCKET_VERSIONING);
+        assertThat(S3Router.route("GET", "photos", null, Set.of("acl")))
+                .isEqualTo(S3Action.GET_BUCKET_ACL);
+    }
+
+    @Test
+    void objectOps() {
+        assertThat(S3Router.route("PUT", "photos", "cat.jpg", Set.of())).isEqualTo(S3Action.PUT_OBJECT);
+        assertThat(S3Router.route("GET", "photos", "cat.jpg", Set.of())).isEqualTo(S3Action.GET_OBJECT);
+        assertThat(S3Router.route("HEAD", "photos", "cat.jpg", Set.of())).isEqualTo(S3Action.HEAD_OBJECT);
+        assertThat(S3Router.route("DELETE", "photos", "a/b/c.jpg", Set.of()))
+                .isEqualTo(S3Action.DELETE_OBJECT);
+    }
+
+    @Test
+    void unsupportedMethod() {
+        assertThat(S3Router.route("PATCH", "photos", "cat.jpg", Set.of())).isEqualTo(S3Action.UNSUPPORTED);
+    }
+}

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3XmlTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3XmlTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class S3XmlTest {
+
+    @Test
+    void errorBody() {
+        String xml = S3Xml.error(S3ErrorCode.NO_SUCH_KEY, "nope", "/b/k", "req-1");
+        assertThat(xml).contains("<Code>NoSuchKey</Code>")
+                .contains("<Message>nope</Message>")
+                .contains("<Resource>/b/k</Resource>")
+                .contains("<RequestId>req-1</RequestId>");
+    }
+
+    @Test
+    void listAllMyBuckets() {
+        String xml = S3Xml.listAllMyBuckets(List.of("photos", "videos"));
+        assertThat(xml).contains("<Name>photos</Name>").contains("<Name>videos</Name>")
+                .contains(S3Xml.NS);
+    }
+
+    @Test
+    void listBucketTruncationAndContents() {
+        String xml = S3Xml.listBucket("photos", "a/", "/", 1000,
+                List.of(new S3Xml.Content("a/cat.jpg", 42, 0L, null)),
+                List.of("a/sub/"), null, "TOKEN", null);
+        assertThat(xml).contains("<Key>a/cat.jpg</Key>")
+                .contains("<Size>42</Size>")
+                .contains("<CommonPrefixes><Prefix>a/sub/</Prefix></CommonPrefixes>")
+                .contains("<IsTruncated>true</IsTruncated>")
+                .contains("<NextContinuationToken>TOKEN</NextContinuationToken>");
+    }
+
+    @Test
+    void notTruncatedWhenNoNextToken() {
+        String xml = S3Xml.listBucket("photos", "", null, 1000, List.of(), List.of(), null, null, null);
+        assertThat(xml).contains("<IsTruncated>false</IsTruncated>")
+                .doesNotContain("NextContinuationToken");
+    }
+
+    @Test
+    void escapesSpecialCharactersInKeys() {
+        String xml = S3Xml.listBucket("photos", "", null, 1000,
+                List.of(new S3Xml.Content("a & b <c>.jpg", 1, 0L, null)), List.of(), null, null, null);
+        assertThat(xml).contains("a &amp; b &lt;c&gt;.jpg").doesNotContain("a & b <c>");
+    }
+
+    @Test
+    void locationConstraintEmptyForUsEast1() {
+        assertThat(S3Xml.locationConstraint("us-east-1")).contains("<LocationConstraint")
+                .doesNotContain("us-east-1<");
+        assertThat(S3Xml.locationConstraint("eu-west-1")).contains(">eu-west-1<");
+    }
+
+    @Test
+    void copyObjectResultQuotesEtag() {
+        String xml = S3Xml.copyObjectResult("abc123", 0L);
+        assertThat(xml).contains("<CopyObjectResult>")
+                .contains("<ETag>\"abc123\"</ETag>")
+                .contains("<LastModified>");
+    }
+
+    @Test
+    void deleteResultListsDeletedAndErrors() {
+        String xml = S3Xml.deleteResult(List.of("a.txt"),
+                List.<String[]>of(new String[]{"b.txt", "AccessDenied", "nope"}));
+        assertThat(xml).contains("<Deleted><Key>a.txt</Key></Deleted>")
+                .contains("<Error><Key>b.txt</Key><Code>AccessDenied</Code><Message>nope</Message></Error>");
+    }
+
+    @Test
+    void versioningAndAclAreWellFormed() {
+        assertThat(S3Xml.versioningConfiguration()).contains("VersioningConfiguration").contains(S3Xml.NS);
+        String acl = S3Xml.accessControlPolicy();
+        assertThat(acl).contains("<AccessControlPolicy")
+                .contains("<Permission>FULL_CONTROL</Permission>")
+                .contains("xsi:type=\"CanonicalUser\"");
+    }
+
+    @Test
+    void declaresXmlPrologue() {
+        assertThat(S3Xml.error(S3ErrorCode.INTERNAL_ERROR, null, null, "r"))
+                .startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    }
+
+    @Test
+    void errorUsesDefaultMessageWhenNull() {
+        assertThat(S3Xml.error(S3ErrorCode.NO_SUCH_BUCKET, null, null, "r"))
+                .contains("<Message>" + S3ErrorCode.NO_SUCH_BUCKET.defaultMessage() + "</Message>");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>candybox-protocol</module>
         <module>candybox-server</module>
         <module>candybox-client</module>
+        <module>candybox-s3-gateway</module>
         <module>candybox-integration-tests</module>
         <module>candybox-dist</module>
     </modules>
@@ -33,6 +34,7 @@
         <bookkeeper.version>4.17.1</bookkeeper.version>
         <zookeeper.version>3.9.2</zookeeper.version>
         <curator.version>5.6.0</curator.version>
+        <netty.version>4.1.118.Final</netty.version>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.6</logback.version>
         <junit.version>5.10.2</junit.version>
@@ -86,8 +88,22 @@
                 <artifactId>candybox-client</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>me.predatorray.candybox</groupId>
+                <artifactId>candybox-s3-gateway</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- third-party -->
+            <!-- Align every Netty artifact (incl. those BookKeeper pulls transitively) to one version
+                 so the gateway's codec-http and its siblings can't diverge on the IT classpath. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.bookkeeper</groupId>
                 <artifactId>bookkeeper-server</artifactId>


### PR DESCRIPTION
Introduce an anonymous, path-style, S3-compatible HTTP gateway that translates the S3 REST/XML protocol onto the Candybox client. The gateway is a stateless leaf module built on Netty, intended to run behind an HTTP(S) load balancer (which terminates TLS); it depends only on candybox-client/common/coordination, never the LSM/BookKeeper internals.

Implemented (v1):
- Bucket CRUD + ListBuckets; single-shot PutObject/GetObject/HeadObject/ DeleteObject; same-bucket CopyObject; batch DeleteObjects.
- ListObjectsV2/V1 with gateway-side delimiter rollup (CommonPrefixes) and base64 continuation tokens.
- Deterministic CRC32C-derived ETag (computed locally on PUT, consistent with the stored value).
- Full S3 <Error> model mapped from the Candybox exception hierarchy, aws-chunked body decoding, ignored Authorization (anonymous), and canned ?location/?versioning/?acl startup probes.

Design: blocking client calls run on a dedicated executor group off the Netty I/O loop. A narrow CandyStore SPI fronts CandyboxClient so the handler is unit-tested against an in-memory fake via EmbeddedChannel.

Deferred (documented in S3_GATEWAY_PLAN.md §16, each needs new Candybox capabilities): multipart upload, real MD5 ETags, Range GET, virtual-host addressing, SigV4.

Wiring: new module + Netty BOM in the root pom (aligns Netty with BookKeeper's transitives); dist bundles the gateway jar, a bin/candybox-s3-gateway launcher, and a config example. S3GatewayIT drives it end-to-end over embedded BookKeeper + ZooKeeper + a real node.