### PR TITLE
Add ceph/s3-tests S3 compatibility harness + CI gate

### DIFF
--- a/.github/workflows/s3-compat.yml
+++ b/.github/workflows/s3-compat.yml
@@ -1,0 +1,158 @@
+name: S3 compatibility
+
+# Runs the ceph/s3-tests gate against a from-source build of the S3 gateway on EVERY PR and every
+# push to main -- regardless of which module changed -- because a change anywhere (LSM, BookKeeper
+# SPI, client, protocol) can break the gateway end-to-end. No `paths:` filter, deliberately.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Manual trigger to (re)calibrate the allowlist on a native amd64 runner and download the result.
+  workflow_dispatch:
+    inputs:
+      calibrate:
+        description: 'Run --calibrate and upload allowlist.txt as an artifact (does not gate).'
+        type: boolean
+        default: false
+
+concurrency:
+  group: s3-compat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  s3-tests:
+    name: ceph/s3-tests gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # to post the pass/fail comment
+    env:
+      COMPOSE_FILE: compat/s3-tests/docker-compose.ci.yml
+      S3_ENDPOINT: http://127.0.0.1:9711
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the candybox image from THIS checkout (not Docker Hub) so the gate tests current code.
+      - name: Build candybox:ci from source
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: candybox:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # `up -d` honours depends_on conditions (bookies healthy -> node healthy -> gateway), so
+      # ordering is correct; the preflight step below confirms end-to-end readiness. (We avoid
+      # `--wait` because the one-shot bk-init exits 0, which `--wait` misreads as a failure.)
+      - name: Start slimmed stack
+        run: docker compose up -d --no-build
+
+      # Drive a real PUT bucket through the gateway until the full path (gateway -> node -> bookies)
+      # answers, so the suite never races a not-yet-serving cluster.
+      - name: Wait for the gateway to serve
+        run: |
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT "$S3_ENDPOINT/ci-preflight" || true)
+            if [ "$code" = "200" ]; then
+              curl -s -o /dev/null -X DELETE "$S3_ENDPOINT/ci-preflight" || true
+              echo "gateway is serving (PUT bucket -> $code)"; exit 0
+            fi
+            echo "attempt $i: PUT bucket -> ${code:-no-response}; retrying"; sleep 5
+          done
+          echo "gateway did not become ready in time"; exit 1
+
+      # Provisional (uncalibrated) seed allowlist -> report only; a real one -> gate. Detected by the
+      # marker the seed file carries, which `run.sh --calibrate` strips when it rewrites the file.
+      - name: Decide mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.calibrate }}" = "true" ]; then
+            echo "mode=calibrate" >> "$GITHUB_OUTPUT"
+          elif grep -q "PROVISIONAL SEED" compat/s3-tests/allowlist.txt; then
+            echo "mode=report" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=gate" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ceph/s3-tests
+        id: run
+        run: |
+          set -o pipefail
+          mode="${{ steps.mode.outputs.mode }}"
+          rc=0
+          case "$mode" in
+            calibrate) compat/s3-tests/run.sh --calibrate 2>&1 | tee gate.log ;;
+            gate)      compat/s3-tests/run.sh            2>&1 | tee gate.log || rc=$? ;;
+            report)    compat/s3-tests/run.sh --all      2>&1 | tee gate.log ;;
+          esac
+
+          summary=$(grep -E '^=+ .*(passed|failed|error|no tests ran)' gate.log | tail -1 | sed 's/=//g; s/^ *//; s/ *$//')
+          [ -z "$summary" ] && summary="(no pytest summary captured)"
+
+          {
+            case "$mode" in
+              gate)      [ "$rc" = "0" ] && echo "### ✅ S3 compatibility gate passed" || echo "### ❌ S3 compatibility gate FAILED" ;;
+              report)    echo "### ℹ️ S3 compatibility report (allowlist is the provisional seed — not gating)" ;;
+              calibrate) echo "### 🔧 S3 compatibility calibration run" ;;
+            esac
+            echo ""
+            echo "- mode: \`$mode\`"
+            echo "- result: \`$summary\`"
+            if grep -qE ' FAILED' gate.log; then
+              echo ""
+              echo "<details><summary>Failed tests</summary>"
+              echo ""
+              echo '```'
+              grep -E ' FAILED' gate.log | awk '{print $1}' | sort -u
+              echo '```'
+              echo "</details>"
+            fi
+            if [ "$mode" = "report" ]; then
+              echo ""
+              echo "> Calibrate to turn this into a gate: run the **S3 compatibility** workflow with \`calibrate=true\` (or \`compat/s3-tests/run.sh --calibrate\` locally), then commit \`compat/s3-tests/allowlist.txt\`."
+            fi
+          } | tee summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          exit $rc
+
+      - name: Upload calibrated allowlist
+        if: ${{ steps.mode.outputs.mode == 'calibrate' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: allowlist.txt
+          path: compat/s3-tests/allowlist.txt
+
+      - name: Comment results on PR
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('summary.md') != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- s3-compat -->';
+            const body = marker + '\n' + fs.readFileSync('summary.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Dump container logs on failure
+        if: ${{ failure() }}
+        run: docker compose logs --no-color --tail 200
+
+      - name: Tear down
+        if: ${{ always() }}
+        run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ per bucket keeps reads and writes consistent during failover.
 ### With Docker Compose (recommended)
 
 The bundled [`docker-compose.yml`](docker-compose.yml) starts the full stack — ZooKeeper, 3
-BookKeeper bookies, and 3 Candybox nodes — using the published
+BookKeeper bookies, 3 Candybox nodes, and the S3 gateway (on `:9711`) — using the published
 [`zetaplusae/candybox`](https://hub.docker.com/r/zetaplusae/candybox) image. Store and read an
 object with the bundled `cli` service:
 
@@ -54,6 +54,11 @@ docker compose run --rm cli get photos hello.txt   # -> hello candybox
 ```
 
 Tear it down with `docker compose down` (add `-v` to also wipe the data volumes).
+
+The gateway's S3 compatibility is verified against the industry-standard
+[`ceph/s3-tests`](https://github.com/ceph/s3-tests) suite — see
+[`compat/s3-tests/`](compat/s3-tests/) (`compat/s3-tests/run.sh --calibrate` against the running
+gateway).
 
 ## Storing and retrieving objects
 

--- a/compat/s3-tests/.gitignore
+++ b/compat/s3-tests/.gitignore
@@ -1,0 +1,2 @@
+# Cloned suite, venv, rendered config and calibration output -- all reproducible from run.sh.
+.work/

--- a/compat/s3-tests/README.md
+++ b/compat/s3-tests/README.md
@@ -75,7 +75,7 @@ docker compose -f compat/s3-tests/docker-compose.ci.yml down -v
 | `S3_ENDPOINT` | `http://127.0.0.1:9711`                       | Gateway base URL. Use an **IP** host, not `localhost`, so boto3 stays path-style. |
 | `S3TESTS_REF` | `master`                                      | `ceph/s3-tests` ref to pin. Calibration records the resolved SHA in the allowlist header. |
 | `S3TESTS_REPO`| `https://github.com/ceph/s3-tests.git`        | Clone URL.                               |
-| `TEST_PATH`   | `s3tests_boto3/functional/test_s3.py`         | Suite path to run.                       |
+| `TEST_PATH`   | `s3tests/functional/test_s3.py`         | Suite path to run.                       |
 | `PYTEST_ARGS` | _(empty)_                                     | Extra args appended to pytest.           |
 
 ## The allowlist as a contract

--- a/compat/s3-tests/README.md
+++ b/compat/s3-tests/README.md
@@ -1,0 +1,108 @@
+# S3 compatibility tests (ceph/s3-tests)
+
+This harness runs the de-facto industry-standard S3 compatibility suite,
+[`ceph/s3-tests`](https://github.com/ceph/s3-tests), against the Candybox S3 gateway
+(`candybox-s3-gateway`). It is the same suite used to validate Ceph RGW, Garage, SeaweedFS and
+most other S3 clones, so a passing allowlist is a meaningful, externally-recognised statement of
+"S3-compatible — for this subset."
+
+The suite itself is **not** vendored. `run.sh` clones it on demand, pins it to a git ref, builds a
+throwaway virtualenv, and points it at a gateway endpoint. Everything it generates lives under
+`.work/` (git-ignored).
+
+## What can pass
+
+The v1 gateway is **anonymous** (the `Authorization` header is accepted and ignored) and
+**path-style only**, and it implements a deliberately small slice of S3:
+
+| Supported (allowlist candidates)        | Not supported in v1 (excluded)                          |
+|------------------------------------------|---------------------------------------------------------|
+| Bucket create / head / delete            | Versioning                                              |
+| ListObjectsV2: prefix, delimiter,        | Multipart upload                                        |
+| max-keys, continuation-token, start-after| ACLs / bucket policy / ownership                        |
+| Object PUT / GET / HEAD / DELETE         | Range GET and conditional GET (If-Match/If-None-Match)  |
+| Multi-object delete                      | Tagging, lifecycle, CORS, SSE                           |
+| `x-amz-meta-*` user metadata, CRC32C ETag| Per-user auth / multi-account isolation                 |
+
+Because auth is ignored, the suite's `[s3 alt]` / `[s3 tenant]` accounts all collapse onto one
+anonymous namespace — multi-user tests can't pass and aren't in the allowlist.
+
+## Running
+
+The gateway needs a live cluster behind it. Two ways to stand one up:
+
+| Stack | Brings up | When |
+|-------|-----------|------|
+| `docker-compose.yml` (repo root) | ZK + 3 bookies + **3** nodes + gateway, from the **published** `zetaplusae/candybox` image | quick demo against a release image |
+| `compat/s3-tests/docker-compose.ci.yml` | ZK + 3 bookies + **1** node + gateway, **built from your local source** | the gate, and the recommended path on a laptop |
+
+On an Apple-Silicon laptop, prefer the **CI compose**: building from source produces a native
+arm64 candybox image (the published one is amd64-only and runs emulated), so only the upstream
+BookKeeper image emulates. Both expose the gateway on `:9711`.
+
+```bash
+# From the repo root. Build the candybox image from source, then start the slimmed stack.
+docker compose -f compat/s3-tests/docker-compose.ci.yml build
+docker compose -f compat/s3-tests/docker-compose.ci.yml up -d
+
+# Wait until the gateway actually serves (PUT a throwaway bucket until it answers 200).
+until [ "$(curl -s -o /dev/null -w '%{http_code}' -X PUT localhost:9711/preflight)" = "200" ]; do sleep 3; done
+curl -s -o /dev/null -X DELETE localhost:9711/preflight
+
+# First run: discover exactly what passes and record it as the allowlist.
+compat/s3-tests/run.sh --calibrate
+
+# Thereafter: regression-gate against the calibrated allowlist (non-zero exit on any failure).
+compat/s3-tests/run.sh
+
+# Tear down (–v also wipes the data volumes).
+docker compose -f compat/s3-tests/docker-compose.ci.yml down -v
+```
+
+### Modes
+
+| Command                         | What it does                                                              |
+|---------------------------------|---------------------------------------------------------------------------|
+| `run.sh`                        | Runs only `allowlist.txt` — the compatibility gate.                       |
+| `run.sh --all`                  | Runs the full boto3 functional suite and reports (expect many failures).  |
+| `run.sh --calibrate`            | Runs `--all`, then rewrites `allowlist.txt` with the tests that PASSED, stamping the suite commit + endpoint. |
+| `run.sh -k test_bucket_list_empty` | Passes `-k EXPR` straight through to pytest for poking at one test.    |
+
+### Environment overrides
+
+| Var           | Default                                       | Purpose                                  |
+|---------------|-----------------------------------------------|------------------------------------------|
+| `S3_ENDPOINT` | `http://127.0.0.1:9711`                       | Gateway base URL. Use an **IP** host, not `localhost`, so boto3 stays path-style. |
+| `S3TESTS_REF` | `master`                                      | `ceph/s3-tests` ref to pin. Calibration records the resolved SHA in the allowlist header. |
+| `S3TESTS_REPO`| `https://github.com/ceph/s3-tests.git`        | Clone URL.                               |
+| `TEST_PATH`   | `s3tests_boto3/functional/test_s3.py`         | Suite path to run.                       |
+| `PYTEST_ARGS` | _(empty)_                                     | Extra args appended to pytest.           |
+
+## The allowlist as a contract
+
+`allowlist.txt` is the checked-in, authoritative pass set — the same "shared external suite defines
+the bar" philosophy as the project's `LedgerStoreContract` / `CoordinationServiceContract`. The
+seed shipped here is **provisional** (marked as such in the file) until a `--calibrate` run pins it
+to a real suite revision. When the gateway gains a feature (e.g. multipart in a later phase),
+re-calibrate and the allowlist grows on its own.
+
+Requirements on the runner host: `python3` (with `venv`), `git`, and network access to clone the
+suite and pip-install boto3/pytest the first time.
+
+## In CI
+
+[`.github/workflows/s3-compat.yml`](../../.github/workflows/s3-compat.yml) runs this gate on **every
+PR and every push to `main`**, with **no path filter** — a change in any module (LSM, BookKeeper
+SPI, client, protocol) can break the gateway end-to-end, so the gate always runs. It builds
+`candybox:ci` from the checkout (never pulls), starts `docker-compose.ci.yml`, runs the suite, and
+posts a sticky pass/fail comment on the PR plus a job summary.
+
+Two behaviours keep it honest:
+
+- **Provisional vs calibrated.** While `allowlist.txt` still carries the `PROVISIONAL SEED` marker,
+  the workflow runs `--all` in **report-only** mode (never red) and the comment nudges you to
+  calibrate. Once you commit a calibrated allowlist (the marker is gone), it becomes a real **gate**
+  that fails the build on any regression.
+- **Calibrate on a native runner.** Trigger the workflow manually (Actions → *S3 compatibility* →
+  Run workflow → `calibrate = true`) to run `--calibrate` on a native amd64 runner — faster than an
+  emulated laptop — then download the `allowlist.txt` artifact and commit it.

--- a/compat/s3-tests/allowlist.txt
+++ b/compat/s3-tests/allowlist.txt
@@ -1,28 +1,160 @@
-# Compatibility allowlist for the Candybox S3 gateway -- ceph/s3-tests.
+# Calibrated allowlist for the Candybox S3 gateway -- ceph/s3-tests.
 #
-# *** PROVISIONAL SEED -- not yet calibrated against a running gateway. ***
-# Replace this file with a real, suite-pinned list by running:
+# These are the test node IDs that PASSED against the gateway. Regenerate with:
 #     compat/s3-tests/run.sh --calibrate
+# and run the gate with:
+#     compat/s3-tests/run.sh
 #
-# These are the boto3 functional tests we EXPECT the v1 gateway to satisfy, given that it is
-# anonymous + path-style and supports: bucket create/head/delete, ListObjectsV2-style listing
-# (prefix / delimiter / max-keys / continuation-token), object PUT/GET/HEAD/DELETE, multi-object
-# delete, x-amz-meta-* user metadata, and the deterministic CRC32C ETag.
+# suite ref : master (5522d1c)
+# endpoint  : http://127.0.0.1:9711
+# calibrated: 2026-05-31T02:14:41Z
 #
-# Deliberately NOT here (unsupported in v1 -- see S3_GATEWAY_PLAN.md / DESIGN.md): versioning,
-# multipart upload, ACLs / bucket policy, Range and conditional (If-Match/If-None-Match) GETs,
-# tagging, lifecycle, CORS, SSE, and anything that asserts per-user auth or ownership.
-#
-# Node IDs are relative to TEST_PATH (default s3tests/functional/test_s3.py).
-
-s3tests/functional/test_s3.py::test_bucket_list_empty
-s3tests/functional/test_s3.py::test_bucket_list_many
+s3tests/functional/test_s3.py::test_atomic_conditional_write_1mb
+s3tests/functional/test_s3.py::test_atomic_dual_write_1mb
+s3tests/functional/test_s3.py::test_atomic_dual_write_4mb
+s3tests/functional/test_s3.py::test_atomic_dual_write_8mb
+s3tests/functional/test_s3.py::test_atomic_read_1mb
+s3tests/functional/test_s3.py::test_atomic_read_4mb
+s3tests/functional/test_s3.py::test_atomic_read_8mb
+s3tests/functional/test_s3.py::test_atomic_write_1mb
+s3tests/functional/test_s3.py::test_atomic_write_4mb
+s3tests/functional/test_s3.py::test_atomic_write_8mb
+s3tests/functional/test_s3.py::test_basic_key_count
+s3tests/functional/test_s3.py::test_bucket_create_naming_bad_ip
+s3tests/functional/test_s3.py::test_bucket_create_naming_bad_short_one
+s3tests/functional/test_s3.py::test_bucket_create_naming_bad_short_two
+s3tests/functional/test_s3.py::test_bucket_create_naming_bad_starts_nonalpha
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_dash_at_end
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_dash_dot
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_dot_dash
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_dot_dot
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_long
+s3tests/functional/test_s3.py::test_bucket_create_naming_dns_underscore
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_contains_hyphen
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_long_60
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_long_61
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_long_62
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_long_63
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_starts_alpha
+s3tests/functional/test_s3.py::test_bucket_create_naming_good_starts_digit
+s3tests/functional/test_s3.py::test_bucket_create_special_key_names
+s3tests/functional/test_s3.py::test_bucket_delete_nonempty
+s3tests/functional/test_s3.py::test_bucket_head
+s3tests/functional/test_s3.py::test_bucket_head_notexist
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_alt
 s3tests/functional/test_s3.py::test_bucket_list_delimiter_basic
-s3tests/functional/test_s3.py::test_bucket_list_prefix_basic
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_dot
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_none
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_percentage
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_unreadable
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_whitespace
+s3tests/functional/test_s3.py::test_bucket_list_distinct
+s3tests/functional/test_s3.py::test_bucket_list_empty
+s3tests/functional/test_s3.py::test_bucket_list_long_name
+s3tests/functional/test_s3.py::test_bucket_list_many
+s3tests/functional/test_s3.py::test_bucket_list_marker_after_list
+s3tests/functional/test_s3.py::test_bucket_list_marker_none
+s3tests/functional/test_s3.py::test_bucket_list_marker_not_in_list
+s3tests/functional/test_s3.py::test_bucket_list_marker_unreadable
+s3tests/functional/test_s3.py::test_bucket_list_maxkeys_none
 s3tests/functional/test_s3.py::test_bucket_list_maxkeys_one
-s3tests/functional/test_s3.py::test_bucket_create_delete
-s3tests/functional/test_s3.py::test_object_write_read_update_read_delete
-s3tests/functional/test_s3.py::test_object_write_check_etag
-s3tests/functional/test_s3.py::test_object_head_zero_bytes
-s3tests/functional/test_s3.py::test_object_read_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_prefix_alt
+s3tests/functional/test_s3.py::test_bucket_list_prefix_basic
+s3tests/functional/test_s3.py::test_bucket_list_prefix_delimiter_alt
+s3tests/functional/test_s3.py::test_bucket_list_prefix_delimiter_basic
+s3tests/functional/test_s3.py::test_bucket_list_prefix_delimiter_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_prefix_delimiter_prefix_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_prefix_delimiter_prefix_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_prefix_empty
+s3tests/functional/test_s3.py::test_bucket_list_prefix_none
+s3tests/functional/test_s3.py::test_bucket_list_prefix_not_exist
+s3tests/functional/test_s3.py::test_bucket_list_prefix_unreadable
+s3tests/functional/test_s3.py::test_bucket_list_special_prefix
+s3tests/functional/test_s3.py::test_bucket_listv2_both_continuationtoken_startafter
+s3tests/functional/test_s3.py::test_bucket_listv2_continuationtoken
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_alt
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_basic
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_dot
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_none
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_percentage
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_unreadable
+s3tests/functional/test_s3.py::test_bucket_listv2_delimiter_whitespace
+s3tests/functional/test_s3.py::test_bucket_listv2_fetchowner_defaultempty
+s3tests/functional/test_s3.py::test_bucket_listv2_fetchowner_empty
+s3tests/functional/test_s3.py::test_bucket_listv2_many
+s3tests/functional/test_s3.py::test_bucket_listv2_maxkeys_none
+s3tests/functional/test_s3.py::test_bucket_listv2_maxkeys_one
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_alt
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_basic
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_delimiter_alt
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_delimiter_basic
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_delimiter_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_delimiter_prefix_delimiter_not_exist
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_delimiter_prefix_not_exist
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_empty
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_none
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_not_exist
+s3tests/functional/test_s3.py::test_bucket_listv2_prefix_unreadable
+s3tests/functional/test_s3.py::test_bucket_listv2_startafter_after_list
+s3tests/functional/test_s3.py::test_bucket_listv2_startafter_not_in_list
+s3tests/functional/test_s3.py::test_bucket_listv2_startafter_unreadable
+s3tests/functional/test_s3.py::test_buckets_create_then_list
+s3tests/functional/test_s3.py::test_copy_object_ifmatch_good
+s3tests/functional/test_s3.py::test_copy_object_ifnonematch_failed
+s3tests/functional/test_s3.py::test_encrypted_transfer_13b
+s3tests/functional/test_s3.py::test_encrypted_transfer_1b
+s3tests/functional/test_s3.py::test_encrypted_transfer_1kb
+s3tests/functional/test_s3.py::test_encrypted_transfer_1MB
+s3tests/functional/test_s3.py::test_get_obj_tagging
+s3tests/functional/test_s3.py::test_get_object_ifmatch_good
+s3tests/functional/test_s3.py::test_get_object_ifmodifiedsince_good
+s3tests/functional/test_s3.py::test_get_object_ifnonematch_failed
+s3tests/functional/test_s3.py::test_get_object_ifunmodifiedsince_failed
+s3tests/functional/test_s3.py::test_list_buckets_anonymous
 s3tests/functional/test_s3.py::test_multi_object_delete
+s3tests/functional/test_s3.py::test_multi_objectv2_delete
+s3tests/functional/test_s3.py::test_object_acl_full_control_verify_owner
+s3tests/functional/test_s3.py::test_object_anon_put_write_access
+s3tests/functional/test_s3.py::test_object_copy_canned_acl
+s3tests/functional/test_s3.py::test_object_copy_key_not_found
+s3tests/functional/test_s3.py::test_object_copy_retaining_metadata
+s3tests/functional/test_s3.py::test_object_copy_same_bucket
+s3tests/functional/test_s3.py::test_object_copy_verify_contenttype
+s3tests/functional/test_s3.py::test_object_copy_zero_size
+s3tests/functional/test_s3.py::test_object_head_zero_bytes
+s3tests/functional/test_s3.py::test_object_lock_changing_mode_from_governance_with_bypass
+s3tests/functional/test_s3.py::test_object_lock_get_legal_hold
+s3tests/functional/test_s3.py::test_object_lock_put_legal_hold
+s3tests/functional/test_s3.py::test_object_metadata_replaced_on_put
+s3tests/functional/test_s3.py::test_object_presigned_put_object_with_acl
+s3tests/functional/test_s3.py::test_object_presigned_put_object_with_acl_tenant
+s3tests/functional/test_s3.py::test_object_put_authenticated
+s3tests/functional/test_s3.py::test_object_raw_authenticated
+s3tests/functional/test_s3.py::test_object_raw_authenticated_bucket_acl
+s3tests/functional/test_s3.py::test_object_raw_authenticated_object_acl
+s3tests/functional/test_s3.py::test_object_raw_authenticated_object_gone
+s3tests/functional/test_s3.py::test_object_raw_get
+s3tests/functional/test_s3.py::test_object_raw_get_bucket_acl
+s3tests/functional/test_s3.py::test_object_raw_get_object_gone
+s3tests/functional/test_s3.py::test_object_read_not_exist
+s3tests/functional/test_s3.py::test_object_requestid_matches_header_on_error
+s3tests/functional/test_s3.py::test_object_set_get_metadata_none_to_empty
+s3tests/functional/test_s3.py::test_object_set_get_metadata_none_to_good
+s3tests/functional/test_s3.py::test_object_set_get_metadata_overwrite_to_empty
+s3tests/functional/test_s3.py::test_object_write_file
+s3tests/functional/test_s3.py::test_object_write_read_update_read_delete
+s3tests/functional/test_s3.py::test_object_write_with_chunked_transfer_encoding
+s3tests/functional/test_s3.py::test_put_max_kvsize_tags
+s3tests/functional/test_s3.py::test_put_max_tags
+s3tests/functional/test_s3.py::test_put_modify_tags
+s3tests/functional/test_s3.py::test_put_object_ifmatch_good
+s3tests/functional/test_s3.py::test_put_object_ifmatch_overwrite_existed_good
+s3tests/functional/test_s3.py::test_put_object_ifnonmatch_good
+s3tests/functional/test_s3.py::test_put_object_ifnonmatch_nonexisted_good
+s3tests/functional/test_s3.py::test_sse_kms_present
+s3tests/functional/test_s3.py::test_sse_kms_transfer_13b
+s3tests/functional/test_s3.py::test_sse_kms_transfer_1b
+s3tests/functional/test_s3.py::test_sse_kms_transfer_1kb
+s3tests/functional/test_s3.py::test_sse_kms_transfer_1MB

--- a/compat/s3-tests/allowlist.txt
+++ b/compat/s3-tests/allowlist.txt
@@ -1,0 +1,28 @@
+# Compatibility allowlist for the Candybox S3 gateway -- ceph/s3-tests.
+#
+# *** PROVISIONAL SEED -- not yet calibrated against a running gateway. ***
+# Replace this file with a real, suite-pinned list by running:
+#     compat/s3-tests/run.sh --calibrate
+#
+# These are the boto3 functional tests we EXPECT the v1 gateway to satisfy, given that it is
+# anonymous + path-style and supports: bucket create/head/delete, ListObjectsV2-style listing
+# (prefix / delimiter / max-keys / continuation-token), object PUT/GET/HEAD/DELETE, multi-object
+# delete, x-amz-meta-* user metadata, and the deterministic CRC32C ETag.
+#
+# Deliberately NOT here (unsupported in v1 -- see S3_GATEWAY_PLAN.md / DESIGN.md): versioning,
+# multipart upload, ACLs / bucket policy, Range and conditional (If-Match/If-None-Match) GETs,
+# tagging, lifecycle, CORS, SSE, and anything that asserts per-user auth or ownership.
+#
+# Node IDs are relative to TEST_PATH (default s3tests_boto3/functional/test_s3.py).
+
+s3tests_boto3/functional/test_s3.py::test_bucket_list_empty
+s3tests_boto3/functional/test_s3.py::test_bucket_list_many
+s3tests_boto3/functional/test_s3.py::test_bucket_list_delimiter_basic
+s3tests_boto3/functional/test_s3.py::test_bucket_list_prefix_basic
+s3tests_boto3/functional/test_s3.py::test_bucket_list_maxkeys_one
+s3tests_boto3/functional/test_s3.py::test_bucket_create_delete
+s3tests_boto3/functional/test_s3.py::test_object_write_read_update_read_delete
+s3tests_boto3/functional/test_s3.py::test_object_write_check_etag
+s3tests_boto3/functional/test_s3.py::test_object_head_zero_bytes
+s3tests_boto3/functional/test_s3.py::test_object_read_not_exist
+s3tests_boto3/functional/test_s3.py::test_multi_object_delete

--- a/compat/s3-tests/allowlist.txt
+++ b/compat/s3-tests/allowlist.txt
@@ -13,16 +13,16 @@
 # multipart upload, ACLs / bucket policy, Range and conditional (If-Match/If-None-Match) GETs,
 # tagging, lifecycle, CORS, SSE, and anything that asserts per-user auth or ownership.
 #
-# Node IDs are relative to TEST_PATH (default s3tests_boto3/functional/test_s3.py).
+# Node IDs are relative to TEST_PATH (default s3tests/functional/test_s3.py).
 
-s3tests_boto3/functional/test_s3.py::test_bucket_list_empty
-s3tests_boto3/functional/test_s3.py::test_bucket_list_many
-s3tests_boto3/functional/test_s3.py::test_bucket_list_delimiter_basic
-s3tests_boto3/functional/test_s3.py::test_bucket_list_prefix_basic
-s3tests_boto3/functional/test_s3.py::test_bucket_list_maxkeys_one
-s3tests_boto3/functional/test_s3.py::test_bucket_create_delete
-s3tests_boto3/functional/test_s3.py::test_object_write_read_update_read_delete
-s3tests_boto3/functional/test_s3.py::test_object_write_check_etag
-s3tests_boto3/functional/test_s3.py::test_object_head_zero_bytes
-s3tests_boto3/functional/test_s3.py::test_object_read_not_exist
-s3tests_boto3/functional/test_s3.py::test_multi_object_delete
+s3tests/functional/test_s3.py::test_bucket_list_empty
+s3tests/functional/test_s3.py::test_bucket_list_many
+s3tests/functional/test_s3.py::test_bucket_list_delimiter_basic
+s3tests/functional/test_s3.py::test_bucket_list_prefix_basic
+s3tests/functional/test_s3.py::test_bucket_list_maxkeys_one
+s3tests/functional/test_s3.py::test_bucket_create_delete
+s3tests/functional/test_s3.py::test_object_write_read_update_read_delete
+s3tests/functional/test_s3.py::test_object_write_check_etag
+s3tests/functional/test_s3.py::test_object_head_zero_bytes
+s3tests/functional/test_s3.py::test_object_read_not_exist
+s3tests/functional/test_s3.py::test_multi_object_delete

--- a/compat/s3-tests/docker-compose.ci.yml
+++ b/compat/s3-tests/docker-compose.ci.yml
@@ -107,9 +107,10 @@ services:
       CANDYBOX_ZOOKEEPER_CONNECT: zookeeper:2181
       CANDYBOX_ADVERTISED: candybox-1:9709
       CANDYBOX_HEAP_OPTS: "-Xms256m -Xmx512m"
-    # The client (TCP) port being open means the node has bound and is serving.
+    # The client (TCP) port being open means the node has bound and is serving. Use bash explicitly:
+    # /dev/tcp is a bash builtin and the image's /bin/sh is dash, which does not support it.
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9709 || exit 1"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9709"]
       interval: 5s
       timeout: 5s
       retries: 24
@@ -131,7 +132,7 @@ services:
       - "9711:9711"   # S3 HTTP API
       - "9712:9712"   # health/metrics
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9712 || exit 1"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9712"]
       interval: 5s
       timeout: 5s
       retries: 24

--- a/compat/s3-tests/docker-compose.ci.yml
+++ b/compat/s3-tests/docker-compose.ci.yml
@@ -1,0 +1,138 @@
+# Slimmed Candybox stack for the ceph/s3-tests compatibility gate: 1 ZooKeeper + 3 BookKeeper
+# bookies + 1 Candybox node + the S3 gateway. Three bookies are the minimum for the default 3/3/2
+# replication quorum; a single node is enough for the gateway to route to. The candybox image is
+# BUILT FROM THE LOCAL SOURCE (this checkout), never pulled, so it tests the code under review.
+#
+# Used by .github/workflows/s3-compat.yml and runnable locally -- see compat/s3-tests/README.md.
+#
+#   docker compose -f compat/s3-tests/docker-compose.ci.yml build      # build candybox:ci from source
+#   docker compose -f compat/s3-tests/docker-compose.ci.yml up -d --wait
+#   compat/s3-tests/run.sh --calibrate     # or: run.sh  (gate)
+#   docker compose -f compat/s3-tests/docker-compose.ci.yml down -v
+#
+# No `platform:` pins: on the amd64 CI runner everything is native; on an arm64 laptop the
+# candybox image builds native arm64 (fast) and only the upstream amd64-only images emulate.
+
+name: candybox-s3-compat
+
+x-bookie: &bookie
+  image: apache/bookkeeper:4.17.1
+  restart: on-failure
+  depends_on:
+    zookeeper:
+      condition: service_healthy
+    bk-init:
+      condition: service_completed_successfully
+  environment: &bookie-env
+    BK_zkServers: zookeeper:2181
+    BK_metadataServiceUri: zk://zookeeper:2181/ledgers
+    BK_zkLedgersRootPath: /ledgers
+    BK_httpServerEnabled: "true"
+  healthcheck:
+    test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8080/heartbeat || exit 1"]
+    interval: 5s
+    timeout: 5s
+    retries: 24
+    start_period: 20s
+
+services:
+  zookeeper:
+    image: zookeeper:3.9
+    restart: on-failure
+    environment:
+      ZOO_STANDALONE_ENABLED: "true"
+      ZOO_4LW_COMMANDS_WHITELIST: srvr,ruok,stat,mntr
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep -q imok"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 5s
+
+  bk-init:
+    image: apache/bookkeeper:4.17.1
+    restart: "no"
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      BK_zkServers: zookeeper:2181
+      BK_metadataServiceUri: zk://zookeeper:2181/ledgers
+      BK_zkLedgersRootPath: /ledgers
+    working_dir: /opt/bookkeeper
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        python3 scripts/apply-config-from-env.py conf/bk_server.conf
+        bin/bookkeeper shell initnewcluster || bin/bookkeeper shell whatisinstanceid
+
+  bookie1:
+    <<: *bookie
+    hostname: bookie1
+    environment:
+      <<: *bookie-env
+      BK_advertisedAddress: bookie1
+
+  bookie2:
+    <<: *bookie
+    hostname: bookie2
+    environment:
+      <<: *bookie-env
+      BK_advertisedAddress: bookie2
+
+  bookie3:
+    <<: *bookie
+    hostname: bookie3
+    environment:
+      <<: *bookie-env
+      BK_advertisedAddress: bookie3
+
+  # The single storage node. Built from source; the same image serves the gateway below.
+  candybox-1:
+    image: candybox:ci
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    restart: on-failure
+    command: ["/opt/candybox/conf/candybox.properties.example"]
+    depends_on:
+      bookie1:
+        condition: service_healthy
+      bookie2:
+        condition: service_healthy
+      bookie3:
+        condition: service_healthy
+    environment:
+      CANDYBOX_NODE_ID: "1"
+      CANDYBOX_ZOOKEEPER_CONNECT: zookeeper:2181
+      CANDYBOX_ADVERTISED: candybox-1:9709
+      CANDYBOX_HEAP_OPTS: "-Xms256m -Xmx512m"
+    # The client (TCP) port being open means the node has bound and is serving.
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9709 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 15s
+
+  s3-gateway:
+    image: candybox:ci
+    restart: on-failure
+    command: ["candybox-s3-gateway", "/opt/candybox/conf/candybox-s3-gateway.properties.example"]
+    depends_on:
+      candybox-1:
+        condition: service_healthy
+    environment:
+      CANDYBOX_ZOOKEEPER_CONNECT: zookeeper:2181
+      CANDYBOX_S3_BIND: 0.0.0.0:9711
+      CANDYBOX_HEALTH_PORT: "9712"
+      CANDYBOX_HEAP_OPTS: "-Xms256m -Xmx512m"
+    ports:
+      - "9711:9711"   # S3 HTTP API
+      - "9712:9712"   # health/metrics
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9712 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 15s

--- a/compat/s3-tests/run.sh
+++ b/compat/s3-tests/run.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Run the ceph/s3-tests S3-compatibility suite against a running Candybox S3 gateway.
+#
+# The gateway needs a live cluster behind it. The easy path is docker compose from the repo root:
+#
+#     docker compose up -d                 # cluster + s3-gateway (published on :9711)
+#     compat/s3-tests/run.sh --calibrate   # first run: discover what passes -> allowlist.txt
+#     compat/s3-tests/run.sh               # thereafter: regression-gate the allowlist
+#
+# Modes:
+#   (default)     run only the tests in allowlist.txt (the compatibility regression gate)
+#   --all         run the whole boto3 functional suite and report (expect many failures: the
+#                 v1 gateway is anonymous, path-style, no versioning/multipart/ACL/Range/conditionals)
+#   --calibrate   run --all, then rewrite allowlist.txt with exactly the tests that PASSED,
+#                 stamping the suite commit + endpoint they were calibrated against
+#   -k EXPR       passed through to pytest (handy for poking at a single test)
+#   -h|--help     this help
+#
+# Environment overrides:
+#   S3_ENDPOINT   gateway base URL                (default: http://127.0.0.1:9711)
+#   S3TESTS_REF   ceph/s3-tests git ref to pin    (default: master; calibrate records the SHA)
+#   S3TESTS_REPO  clone URL                        (default: https://github.com/ceph/s3-tests.git)
+#   TEST_PATH     suite path under the checkout    (default: s3tests_boto3/functional/test_s3.py)
+#   PYTEST_ARGS   extra args appended to pytest    (default: empty)
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$HERE/.work"
+SUITE="$WORK/s3-tests"
+VENV="$WORK/venv"
+CONF="$WORK/s3tests.conf"
+ALLOWLIST="$HERE/allowlist.txt"
+
+S3_ENDPOINT="${S3_ENDPOINT:-http://127.0.0.1:9711}"
+S3TESTS_REF="${S3TESTS_REF:-master}"
+S3TESTS_REPO="${S3TESTS_REPO:-https://github.com/ceph/s3-tests.git}"
+TEST_PATH="${TEST_PATH:-s3tests_boto3/functional/test_s3.py}"
+PYTEST_ARGS="${PYTEST_ARGS:-}"
+
+MODE="allowlist"
+EXTRA_PYTEST=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)        MODE="all"; shift ;;
+    --calibrate)  MODE="calibrate"; shift ;;
+    -k)           EXTRA_PYTEST+=("-k" "$2"); shift 2 ;;
+    -h|--help)    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)            EXTRA_PYTEST+=("$1"); shift ;;
+  esac
+done
+
+log() { printf '\033[1;34m[s3-tests]\033[0m %s\n' "$*" >&2; }
+
+# --- endpoint -> host/port (path-style requires an IP literal host) -----------------------------
+ENDPOINT_NO_SCHEME="${S3_ENDPOINT#*://}"
+HOST="${ENDPOINT_NO_SCHEME%%:*}"
+PORT="${ENDPOINT_NO_SCHEME##*:}"
+[[ "$PORT" == "$ENDPOINT_NO_SCHEME" ]] && PORT="80"
+if [[ "$HOST" == "localhost" ]]; then
+  log "WARNING: host 'localhost' makes boto3 attempt virtual-hosted addressing; using 127.0.0.1 instead."
+  HOST="127.0.0.1"
+fi
+
+# --- fetch + pin the suite ----------------------------------------------------------------------
+mkdir -p "$WORK"
+if [[ ! -d "$SUITE/.git" ]]; then
+  log "cloning $S3TESTS_REPO -> $SUITE"
+  git clone --quiet "$S3TESTS_REPO" "$SUITE"
+fi
+log "checking out ref '$S3TESTS_REF'"
+git -C "$SUITE" fetch --quiet origin
+git -C "$SUITE" checkout --quiet "$S3TESTS_REF"
+git -C "$SUITE" pull --quiet --ff-only origin "$S3TESTS_REF" 2>/dev/null || true
+SUITE_SHA="$(git -C "$SUITE" rev-parse --short HEAD)"
+log "suite at $SUITE_SHA"
+
+# --- venv ---------------------------------------------------------------------------------------
+if [[ ! -x "$VENV/bin/pytest" ]]; then
+  log "creating venv + installing the suite (one-time)"
+  python3 -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip
+  "$VENV/bin/pip" install --quiet -r "$SUITE/requirements.txt"
+  "$VENV/bin/pip" install --quiet -e "$SUITE"
+fi
+
+# --- render config ------------------------------------------------------------------------------
+sed -e "s/__HOST__/$HOST/g" -e "s/__PORT__/$PORT/g" "$HERE/s3tests.conf.in" > "$CONF"
+log "endpoint http://$HOST:$PORT  (config: $CONF)"
+
+export S3TEST_CONF="$CONF"
+cd "$SUITE"
+
+run_pytest() { "$VENV/bin/pytest" -p no:cacheprovider "$@"; }
+
+# shellcheck disable=SC2206  # intentional word-splitting of the PYTEST_ARGS env string
+read -r -a PYTEST_ARGS_ARR <<< "${PYTEST_ARGS}"
+
+case "$MODE" in
+  allowlist)
+    if [[ ! -s "$ALLOWLIST" ]]; then
+      log "allowlist.txt is empty -- run '$0 --calibrate' first."; exit 2
+    fi
+    IDS=()
+    while IFS= read -r line; do
+      [[ -z "$line" || "$line" == \#* ]] && continue
+      IDS+=("$line")
+    done < "$ALLOWLIST"
+    log "running ${#IDS[@]} allowlisted tests"
+    run_pytest -v "${EXTRA_PYTEST[@]+"${EXTRA_PYTEST[@]}"}" "${IDS[@]}" \
+      "${PYTEST_ARGS_ARR[@]+"${PYTEST_ARGS_ARR[@]}"}"
+    ;;
+
+  all)
+    log "running the FULL boto3 functional suite (failures are expected for unsupported features)"
+    run_pytest -v "${EXTRA_PYTEST[@]+"${EXTRA_PYTEST[@]}"}" "$TEST_PATH" \
+      "${PYTEST_ARGS_ARR[@]+"${PYTEST_ARGS_ARR[@]}"}" || true
+    ;;
+
+  calibrate)
+    log "calibrating: running the full suite and recording the tests that PASS"
+    REPORT="$WORK/calibrate.out"
+    run_pytest -v "${EXTRA_PYTEST[@]+"${EXTRA_PYTEST[@]}"}" "$TEST_PATH" \
+      "${PYTEST_ARGS_ARR[@]+"${PYTEST_ARGS_ARR[@]}"}" | tee "$REPORT" || true
+    {
+      echo "# Calibrated allowlist for the Candybox S3 gateway -- ceph/s3-tests."
+      echo "#"
+      echo "# These are the test node IDs that PASSED against the gateway. Regenerate with:"
+      echo "#     compat/s3-tests/run.sh --calibrate"
+      echo "# and run the gate with:"
+      echo "#     compat/s3-tests/run.sh"
+      echo "#"
+      echo "# suite ref : $S3TESTS_REF ($SUITE_SHA)"
+      echo "# endpoint  : http://$HOST:$PORT"
+      echo "# calibrated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      echo "#"
+      grep -E ' PASSED' "$REPORT" | awk '{print $1}' | sort -u
+    } > "$ALLOWLIST"
+    PASSES="$(grep -vcE '^\s*(#|$)' "$ALLOWLIST" || true)"
+    log "wrote $PASSES passing tests to $ALLOWLIST"
+    ;;
+esac

--- a/compat/s3-tests/run.sh
+++ b/compat/s3-tests/run.sh
@@ -21,7 +21,7 @@
 #   S3_ENDPOINT   gateway base URL                (default: http://127.0.0.1:9711)
 #   S3TESTS_REF   ceph/s3-tests git ref to pin    (default: master; calibrate records the SHA)
 #   S3TESTS_REPO  clone URL                        (default: https://github.com/ceph/s3-tests.git)
-#   TEST_PATH     suite path under the checkout    (default: s3tests_boto3/functional/test_s3.py)
+#   TEST_PATH     suite path under the checkout    (default: s3tests/functional/test_s3.py)
 #   PYTEST_ARGS   extra args appended to pytest    (default: empty)
 #
 set -euo pipefail
@@ -36,7 +36,7 @@ ALLOWLIST="$HERE/allowlist.txt"
 S3_ENDPOINT="${S3_ENDPOINT:-http://127.0.0.1:9711}"
 S3TESTS_REF="${S3TESTS_REF:-master}"
 S3TESTS_REPO="${S3TESTS_REPO:-https://github.com/ceph/s3-tests.git}"
-TEST_PATH="${TEST_PATH:-s3tests_boto3/functional/test_s3.py}"
+TEST_PATH="${TEST_PATH:-s3tests/functional/test_s3.py}"
 PYTEST_ARGS="${PYTEST_ARGS:-}"
 
 MODE="allowlist"

--- a/compat/s3-tests/s3tests.conf.in
+++ b/compat/s3-tests/s3tests.conf.in
@@ -1,0 +1,64 @@
+# ceph/s3-tests configuration template for the Candybox S3 gateway.
+#
+# run.sh renders this into .work/s3tests.conf, substituting __HOST__ / __PORT__ from $S3_ENDPOINT.
+#
+# Notes specific to Candybox:
+#  * The gateway is ANONYMOUS: it accepts and ignores the Authorization header. The credentials
+#    below are therefore arbitrary placeholders -- every "account" maps to the same anonymous
+#    namespace. Multi-user / ACL / tenant-isolation tests cannot pass and are not in the allowlist.
+#  * __HOST__ should be an IP literal (e.g. 127.0.0.1), not a DNS name. boto3 falls back to
+#    path-style addressing when the host is an IP, which is the only addressing the gateway speaks.
+#  * Plain HTTP only -- TLS is expected to terminate at a load balancer in production.
+
+[DEFAULT]
+host = __HOST__
+port = __PORT__
+is_secure = False
+ssl_verify = False
+
+[fixtures]
+bucket prefix = candybox-{random}-
+iam name prefix = s3-tests-
+iam path prefix = /s3-tests/
+
+[s3 main]
+display_name = candybox-main
+user_id = candybox-main
+email = main@candybox.test
+api_name = default
+access_key = candybox
+secret_key = candybox
+
+[s3 alt]
+display_name = candybox-alt
+user_id = candybox-alt
+email = alt@candybox.test
+access_key = candyalt
+secret_key = candyalt
+
+[s3 tenant]
+display_name = candybox-tenant
+user_id = candybox-tenant
+email = tenant@candybox.test
+access_key = candytenant
+secret_key = candytenant
+tenant = candytenant
+
+[iam]
+email = iam@candybox.test
+access_key = candyiam
+secret_key = candyiam
+display_name = candybox-iam
+user_id = candybox-iam
+
+[iam root]
+access_key = candyroot
+secret_key = candyroot
+user_id = RGW11111111111111111
+email = root@candybox.test
+
+[iam alt root]
+access_key = candyaltroot
+secret_key = candyaltroot
+user_id = RGW22222222222222222
+email = altroot@candybox.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,37 @@ services:
       - "9729:9709"
       - "9730:9710"
 
+  # Anonymous, path-style S3-compatible HTTP gateway. Stateless client of the cluster; reachable on
+  # the host at :9711 (S3) and :9712 (health). Used by the ceph/s3-tests harness in
+  # compat/s3-tests/. Runs the shipped example config with CANDYBOX_* env overrides applied.
+  s3-gateway:
+    image: zetaplusae/candybox:latest
+    platform: linux/amd64
+    restart: on-failure
+    command: ["candybox-s3-gateway", "/opt/candybox/conf/candybox-s3-gateway.properties.example"]
+    depends_on:
+      candybox-1:
+        condition: service_started
+      candybox-2:
+        condition: service_started
+      candybox-3:
+        condition: service_started
+    environment:
+      CANDYBOX_ZOOKEEPER_CONNECT: zookeeper:2181
+      CANDYBOX_S3_BIND: 0.0.0.0:9711
+      CANDYBOX_HEALTH_PORT: "9712"
+      CANDYBOX_HEAP_OPTS: "-Xms256m -Xmx512m"
+    ports:
+      - "9711:9711"   # S3 HTTP API
+      - "9712:9712"   # health/metrics (HTTP)
+    # The JRE image ships no curl/wget; probe the readiness port with bash's /dev/tcp instead.
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9712 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 20s
+
   # Convenience client. The same image doubles as the `candybox` CLI; this service points it at
   # the cluster (over the internal network) and is only run on demand, never started by `up`:
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,8 +195,9 @@ services:
       - "9711:9711"   # S3 HTTP API
       - "9712:9712"   # health/metrics (HTTP)
     # The JRE image ships no curl/wget; probe the readiness port with bash's /dev/tcp instead.
+    # /bin/sh is dash (no /dev/tcp), so invoke bash explicitly.
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9712 || exit 1"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9712"]
       interval: 10s
       timeout: 5s
       retries: 18


### PR DESCRIPTION
Wire the industry-standard ceph/s3-tests suite against candybox-s3-gateway:

- compat/s3-tests/run.sh clones+pins the suite, builds a venv, renders the config, and runs it in allowlist (gate), --all (report), or --calibrate (rewrite allowlist from what passed) modes.
- allowlist.txt is the checked-in compatibility contract, seeded provisionally until a --calibrate run pins it to a suite revision.
- docker-compose.yml gains an s3-gateway service (:9711); a slimmed docker-compose.ci.yml (1 node, 3 bookies) built from source backs the gate.
- .github/workflows/s3-compat.yml runs on every PR and push to main (no path filter), builds the image from source, runs the suite, and posts a sticky pass/fail PR comment. Report-only until the allowlist is calibrated.