### PR TITLE
Support V1 ListObjects marker + ListObjectVersions in the S3 gateway

### DIFF
--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Handler.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Handler.java
@@ -116,6 +116,7 @@ final class S3Handler extends SimpleChannelInboundHandler<FullHttpRequest> {
                 }
             }
             case LIST_OBJECTS -> listObjects(ctx, request, parts.bucket(), decoder, requestId);
+            case LIST_OBJECT_VERSIONS -> listObjectVersions(ctx, request, parts.bucket(), decoder, requestId);
             case DELETE_OBJECTS -> deleteObjects(ctx, request, parts.bucket(), requestId);
             case GET_BUCKET_LOCATION -> sendXml(ctx, request, HttpResponseStatus.OK,
                     S3Xml.locationConstraint(config.region()), requestId);
@@ -229,17 +230,73 @@ final class S3Handler extends SimpleChannelInboundHandler<FullHttpRequest> {
     private void listObjects(ChannelHandlerContext ctx, FullHttpRequest request, String bucket,
                              QueryStringDecoder decoder, String requestId) {
         Map<String, List<String>> q = decoder.parameters();
+        // ListObjectsV2 is selected by list-type=2; without it this is the V1 ListObjects API, whose
+        // pagination cursor is the (plain, non-opaque) `marker` rather than V2's continuation-token.
+        boolean v2 = "2".equals(first(q, "list-type", null));
         String prefix = first(q, "prefix", "");
         String delimiter = first(q, "delimiter", null);
         int maxKeys = clampMaxKeys(first(q, "max-keys", null));
+
         String continuationToken = first(q, "continuation-token", null);
         String startAfterParam = first(q, "start-after", null);
-        String startAfter = continuationToken != null ? decodeToken(continuationToken) : startAfterParam;
+        String marker = first(q, "marker", null);
+        String startAfter = v2
+                ? (continuationToken != null ? decodeToken(continuationToken) : startAfterParam)
+                : marker;
 
         Listing listing = store.listCandies(bucket, prefix, startAfter, maxKeys);
-
         List<S3Xml.Content> contents = new ArrayList<>();
         Set<String> commonPrefixes = new LinkedHashSet<>();
+        rollUp(listing, prefix, delimiter, contents, commonPrefixes);
+
+        String xml;
+        if (v2) {
+            String nextToken = listing.isTruncated() ? encodeToken(listing.nextStartAfter()) : null;
+            xml = S3Xml.listBucketV2(bucket, prefix, delimiter, maxKeys, contents,
+                    new ArrayList<>(commonPrefixes), continuationToken, nextToken, startAfterParam);
+        } else {
+            // S3 only returns NextMarker when a delimiter is in play; otherwise the client resumes from
+            // the last returned key. Our resume cursor is exactly that last key, so the two agree.
+            String nextMarker = (listing.isTruncated() && delimiter != null) ? listing.nextStartAfter() : null;
+            xml = S3Xml.listBucketV1(bucket, prefix, delimiter, maxKeys, contents,
+                    new ArrayList<>(commonPrefixes), marker, nextMarker, listing.isTruncated());
+        }
+        sendXml(ctx, request, HttpResponseStatus.OK, xml, requestId);
+    }
+
+    /**
+     * ListObjectVersions for the unversioned store: lists each object as its sole latest version. The
+     * store has no version dimension, so this reuses {@code listCandies} and pages by {@code key-marker}
+     * (the {@code version-id-marker} is irrelevant). Mainly here so version-aware clients — e.g. the
+     * s3-tests cleanup, which drains a bucket via {@code list_object_versions} — work against us.
+     */
+    private void listObjectVersions(ChannelHandlerContext ctx, FullHttpRequest request, String bucket,
+                                    QueryStringDecoder decoder, String requestId) {
+        Map<String, List<String>> q = decoder.parameters();
+        String prefix = first(q, "prefix", "");
+        String delimiter = first(q, "delimiter", null);
+        int maxKeys = clampMaxKeys(first(q, "max-keys", null));
+        String keyMarker = first(q, "key-marker", null);
+
+        Listing listing = store.listCandies(bucket, prefix, keyMarker, maxKeys);
+        List<S3Xml.Content> versions = new ArrayList<>();
+        Set<String> commonPrefixes = new LinkedHashSet<>();
+        rollUp(listing, prefix, delimiter, versions, commonPrefixes);
+
+        String nextKeyMarker = listing.isTruncated() ? listing.nextStartAfter() : null;
+        String xml = S3Xml.listVersions(bucket, prefix, delimiter, maxKeys, versions,
+                new ArrayList<>(commonPrefixes), keyMarker, nextKeyMarker);
+        sendXml(ctx, request, HttpResponseStatus.OK, xml, requestId);
+    }
+
+    /**
+     * Folds a {@link Listing} page into object rows and synthesized common prefixes: a key whose first
+     * {@code delimiter} occurrence after {@code prefix} rolls it up into a {@code CommonPrefixes} entry,
+     * otherwise it becomes a content/version row. List entries carry no ETag (the listing API returns no
+     * CRC32C; a HEAD on the key yields the deterministic ETag).
+     */
+    private static void rollUp(Listing listing, String prefix, String delimiter,
+                               List<S3Xml.Content> rows, Set<String> commonPrefixes) {
         for (Listing.Entry e : listing.entries()) {
             String key = e.key();
             if (delimiter != null) {
@@ -250,14 +307,8 @@ final class S3Handler extends SimpleChannelInboundHandler<FullHttpRequest> {
                     continue;
                 }
             }
-            // The listing API returns no CRC32C, so list entries carry no ETag in v1 (clients tolerate
-            // its absence). A HEAD on the individual key returns the deterministic ETag.
-            contents.add(new S3Xml.Content(key, e.contentLength(), e.createdAtMillis(), null));
+            rows.add(new S3Xml.Content(key, e.contentLength(), e.createdAtMillis(), null));
         }
-        String nextToken = listing.isTruncated() ? encodeToken(listing.nextStartAfter()) : null;
-        String xml = S3Xml.listBucket(bucket, prefix, delimiter, maxKeys, contents,
-                new ArrayList<>(commonPrefixes), continuationToken, nextToken, startAfterParam);
-        sendXml(ctx, request, HttpResponseStatus.OK, xml, requestId);
     }
 
     private void deleteObjects(ChannelHandlerContext ctx, FullHttpRequest request, String bucket,

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Router.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Router.java
@@ -33,6 +33,7 @@ final class S3Router {
         DELETE_BUCKET,
         HEAD_BUCKET,
         LIST_OBJECTS,
+        LIST_OBJECT_VERSIONS,
         DELETE_OBJECTS,
         GET_BUCKET_LOCATION,
         GET_BUCKET_VERSIONING,
@@ -84,6 +85,9 @@ final class S3Router {
                 }
                 if (queries.contains("acl")) {
                     yield S3Action.GET_BUCKET_ACL;
+                }
+                if (queries.contains("versions")) {
+                    yield S3Action.LIST_OBJECT_VERSIONS;
                 }
                 yield S3Action.LIST_OBJECTS;
             }

--- a/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Xml.java
+++ b/candybox-s3-gateway/src/main/java/me/predatorray/candybox/s3/S3Xml.java
@@ -81,10 +81,10 @@ final class S3Xml {
     }
 
     /** ListObjectsV2 result. {@code nextContinuationToken} non-null iff truncated. */
-    static String listBucket(String bucket, String prefix, String delimiter, int maxKeys,
-                             List<Content> contents, List<String> commonPrefixes,
-                             String continuationToken, String nextContinuationToken,
-                             String startAfter) {
+    static String listBucketV2(String bucket, String prefix, String delimiter, int maxKeys,
+                               List<Content> contents, List<String> commonPrefixes,
+                               String continuationToken, String nextContinuationToken,
+                               String startAfter) {
         return doc(w -> {
             root(w, "ListBucketResult");
             el(w, "Name", bucket);
@@ -105,9 +105,71 @@ final class S3Xml {
             if (truncated) {
                 el(w, "NextContinuationToken", nextContinuationToken);
             }
-            for (Content c : contents) {
-                w.writeStartElement("Contents");
+            writeContents(w, contents);
+            writeCommonPrefixes(w, commonPrefixes);
+            w.writeEndElement();
+        });
+    }
+
+    /**
+     * ListObjects (V1) result. Differs from V2 only in its pagination cursor: it echoes {@code <Marker>}
+     * and, when a delimiter rolls keys up (matching S3, which omits {@code NextMarker} otherwise),
+     * emits {@code <NextMarker>}; flat listings page from the last returned key. No {@code KeyCount}
+     * (that element is V2-only).
+     */
+    static String listBucketV1(String bucket, String prefix, String delimiter, int maxKeys,
+                               List<Content> contents, List<String> commonPrefixes,
+                               String marker, String nextMarker, boolean truncated) {
+        return doc(w -> {
+            root(w, "ListBucketResult");
+            el(w, "Name", bucket);
+            el(w, "Prefix", prefix == null ? "" : prefix);
+            el(w, "Marker", marker == null ? "" : marker);
+            if (nextMarker != null) {
+                el(w, "NextMarker", nextMarker);
+            }
+            if (delimiter != null) {
+                el(w, "Delimiter", delimiter);
+            }
+            el(w, "MaxKeys", Integer.toString(maxKeys));
+            el(w, "IsTruncated", Boolean.toString(truncated));
+            writeContents(w, contents);
+            writeCommonPrefixes(w, commonPrefixes);
+            w.writeEndElement();
+        });
+    }
+
+    /**
+     * ListObjectVersions result for the unversioned store: every object surfaces as a single latest
+     * {@code <Version>} carrying the literal {@code null} version id (S3's convention for an object in
+     * an unversioned bucket), so version-aware clients — notably the s3-tests cleanup, which enumerates
+     * a bucket via {@code list_object_versions} before deleting — can drain it. Paginated by key-marker;
+     * the version-id marker is always empty since there is only one version per key.
+     */
+    static String listVersions(String bucket, String prefix, String delimiter, int maxKeys,
+                               List<Content> versions, List<String> commonPrefixes,
+                               String keyMarker, String nextKeyMarker) {
+        return doc(w -> {
+            root(w, "ListVersionsResult");
+            el(w, "Name", bucket);
+            el(w, "Prefix", prefix == null ? "" : prefix);
+            el(w, "KeyMarker", keyMarker == null ? "" : keyMarker);
+            el(w, "VersionIdMarker", "");
+            boolean truncated = nextKeyMarker != null;
+            if (truncated) {
+                el(w, "NextKeyMarker", nextKeyMarker);
+                el(w, "NextVersionIdMarker", "");
+            }
+            if (delimiter != null) {
+                el(w, "Delimiter", delimiter);
+            }
+            el(w, "MaxKeys", Integer.toString(maxKeys));
+            el(w, "IsTruncated", Boolean.toString(truncated));
+            for (Content c : versions) {
+                w.writeStartElement("Version");
                 el(w, "Key", c.key());
+                el(w, "VersionId", "null");
+                el(w, "IsLatest", "true");
                 el(w, "LastModified", ISO8601.format(Instant.ofEpochMilli(c.lastModifiedMillis())));
                 if (c.etag() != null) {
                     el(w, "ETag", '"' + c.etag() + '"');
@@ -116,11 +178,7 @@ final class S3Xml {
                 el(w, "StorageClass", "STANDARD");
                 w.writeEndElement();
             }
-            for (String cp : commonPrefixes) {
-                w.writeStartElement("CommonPrefixes");
-                el(w, "Prefix", cp);
-                w.writeEndElement();
-            }
+            writeCommonPrefixes(w, commonPrefixes);
             w.writeEndElement();
         });
     }
@@ -197,6 +255,31 @@ final class S3Xml {
     }
 
     // ---- internals -------------------------------------------------------------------------
+
+    /** Writes the {@code <Contents>} rows shared by the V1 and V2 listing results. */
+    private static void writeContents(XMLStreamWriter w, List<Content> contents) throws XMLStreamException {
+        for (Content c : contents) {
+            w.writeStartElement("Contents");
+            el(w, "Key", c.key());
+            el(w, "LastModified", ISO8601.format(Instant.ofEpochMilli(c.lastModifiedMillis())));
+            if (c.etag() != null) {
+                el(w, "ETag", '"' + c.etag() + '"');
+            }
+            el(w, "Size", Long.toString(c.size()));
+            el(w, "StorageClass", "STANDARD");
+            w.writeEndElement();
+        }
+    }
+
+    /** Writes the {@code <CommonPrefixes>} rollup shared by every listing result. */
+    private static void writeCommonPrefixes(XMLStreamWriter w, List<String> commonPrefixes)
+            throws XMLStreamException {
+        for (String cp : commonPrefixes) {
+            w.writeStartElement("CommonPrefixes");
+            el(w, "Prefix", cp);
+            w.writeEndElement();
+        }
+    }
 
     /** Opens a document root element in the S3 default namespace. */
     private static void root(XMLStreamWriter w, String name) throws XMLStreamException {

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3HandlerTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3HandlerTest.java
@@ -157,6 +157,49 @@ class S3HandlerTest {
     }
 
     @Test
+    void listObjectsV1HonoursMarker() {
+        put("/photos");
+        for (String k : new String[]{"k1", "k2", "k3"}) {
+            put("/photos/" + k, "v".getBytes(StandardCharsets.UTF_8), null);
+        }
+        // No list-type=2 -> V1 ListObjects: the cursor is `marker` and the response echoes <Marker>,
+        // not a continuation token.
+        Response first = get("/photos?max-keys=2");
+        assertThat(first.body).contains("<Key>k1</Key>").contains("<Key>k2</Key>")
+                .doesNotContain("<Key>k3</Key>")
+                .contains("<IsTruncated>true</IsTruncated>")
+                .contains("<Marker></Marker>")
+                .doesNotContain("ContinuationToken");
+
+        Response second = get("/photos?max-keys=2&marker=k2");
+        assertThat(second.body).contains("<Key>k3</Key>")
+                .doesNotContain("<Key>k1</Key>").doesNotContain("<Key>k2</Key>");
+    }
+
+    @Test
+    void listObjectVersionsListsAndPaginatesByKeyMarker() {
+        put("/photos");
+        put("/photos/a.txt", "1".getBytes(StandardCharsets.UTF_8), null);
+        put("/photos/b.txt", "2".getBytes(StandardCharsets.UTF_8), null);
+
+        Response all = get("/photos?versions");
+        assertThat(all.status).isEqualTo(200);
+        assertThat(all.body).contains("<ListVersionsResult")
+                .contains("<Key>a.txt</Key>").contains("<Key>b.txt</Key>")
+                .contains("<VersionId>null</VersionId>")
+                .contains("<IsLatest>true</IsLatest>")
+                .contains("<IsTruncated>false</IsTruncated>");
+
+        // key-marker pagination lets a version-aware client drain the bucket key by key.
+        Response page = get("/photos?versions&max-keys=1");
+        assertThat(page.body).contains("<Key>a.txt</Key>").doesNotContain("<Key>b.txt</Key>")
+                .contains("<IsTruncated>true</IsTruncated>")
+                .contains("<NextKeyMarker>a.txt</NextKeyMarker>");
+        Response next = get("/photos?versions&max-keys=1&key-marker=a.txt");
+        assertThat(next.body).contains("<Key>b.txt</Key>").doesNotContain("<Key>a.txt</Key>");
+    }
+
+    @Test
     void batchDeleteObjects() {
         put("/photos");
         put("/photos/a.txt", "1".getBytes(StandardCharsets.UTF_8), null);

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RouterTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3RouterTest.java
@@ -47,6 +47,8 @@ class S3RouterTest {
                 .isEqualTo(S3Action.GET_BUCKET_VERSIONING);
         assertThat(S3Router.route("GET", "photos", null, Set.of("acl")))
                 .isEqualTo(S3Action.GET_BUCKET_ACL);
+        assertThat(S3Router.route("GET", "photos", null, Set.of("versions")))
+                .isEqualTo(S3Action.LIST_OBJECT_VERSIONS);
     }
 
     @Test

--- a/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3XmlTest.java
+++ b/candybox-s3-gateway/src/test/java/me/predatorray/candybox/s3/S3XmlTest.java
@@ -39,27 +39,64 @@ class S3XmlTest {
     }
 
     @Test
-    void listBucketTruncationAndContents() {
-        String xml = S3Xml.listBucket("photos", "a/", "/", 1000,
+    void listBucketV2TruncationAndContents() {
+        String xml = S3Xml.listBucketV2("photos", "a/", "/", 1000,
                 List.of(new S3Xml.Content("a/cat.jpg", 42, 0L, null)),
                 List.of("a/sub/"), null, "TOKEN", null);
         assertThat(xml).contains("<Key>a/cat.jpg</Key>")
                 .contains("<Size>42</Size>")
                 .contains("<CommonPrefixes><Prefix>a/sub/</Prefix></CommonPrefixes>")
+                .contains("<KeyCount>2</KeyCount>")
                 .contains("<IsTruncated>true</IsTruncated>")
                 .contains("<NextContinuationToken>TOKEN</NextContinuationToken>");
     }
 
     @Test
     void notTruncatedWhenNoNextToken() {
-        String xml = S3Xml.listBucket("photos", "", null, 1000, List.of(), List.of(), null, null, null);
+        String xml = S3Xml.listBucketV2("photos", "", null, 1000, List.of(), List.of(), null, null, null);
         assertThat(xml).contains("<IsTruncated>false</IsTruncated>")
                 .doesNotContain("NextContinuationToken");
     }
 
     @Test
+    void listBucketV1EchoesMarkerAndNextMarker() {
+        String xml = S3Xml.listBucketV1("photos", "a/", "/", 1000,
+                List.of(new S3Xml.Content("a/cat.jpg", 42, 0L, null)),
+                List.of("a/sub/"), "a/aardvark", "a/sub/", true);
+        assertThat(xml).contains("<Marker>a/aardvark</Marker>")
+                .contains("<NextMarker>a/sub/</NextMarker>")
+                .contains("<IsTruncated>true</IsTruncated>")
+                .contains("<Key>a/cat.jpg</Key>")
+                // V1 has no KeyCount / V2 cursor fields.
+                .doesNotContain("KeyCount")
+                .doesNotContain("ContinuationToken");
+    }
+
+    @Test
+    void listBucketV1NoNextMarkerWhenNotTruncated() {
+        String xml = S3Xml.listBucketV1("photos", "", null, 1000,
+                List.of(new S3Xml.Content("k", 1, 0L, null)), List.of(), null, null, false);
+        assertThat(xml).contains("<Marker></Marker>")
+                .contains("<IsTruncated>false</IsTruncated>")
+                .doesNotContain("NextMarker");
+    }
+
+    @Test
+    void listVersionsSurfacesNullVersionIds() {
+        String xml = S3Xml.listVersions("photos", "", null, 1000,
+                List.of(new S3Xml.Content("hello.txt", 5, 0L, null)), List.of(), null, "hello.txt");
+        assertThat(xml).contains("<ListVersionsResult")
+                .contains("<Version>")
+                .contains("<Key>hello.txt</Key>")
+                .contains("<VersionId>null</VersionId>")
+                .contains("<IsLatest>true</IsLatest>")
+                .contains("<NextKeyMarker>hello.txt</NextKeyMarker>")
+                .contains("<IsTruncated>true</IsTruncated>");
+    }
+
+    @Test
     void escapesSpecialCharactersInKeys() {
-        String xml = S3Xml.listBucket("photos", "", null, 1000,
+        String xml = S3Xml.listBucketV2("photos", "", null, 1000,
                 List.of(new S3Xml.Content("a & b <c>.jpg", 1, 0L, null)), List.of(), null, null, null);
         assertThat(xml).contains("a &amp; b &lt;c&gt;.jpg").doesNotContain("a & b <c>");
     }


### PR DESCRIPTION
The gateway only implemented ListObjectsV2 pagination (continuation-token / start-after) and always emitted a V2-shaped ListBucketResult, so two listing paths broke S3 clients:

- V1 ListObjects ignored the `marker` cursor, so paginated v1 listings never advanced (every page restarted from the top).
- ListObjectVersions (GET ?versions) was unrouted and fell through to a plain ListBucketResult with no <Version> entries. Version-aware clients — notably the ceph/s3-tests cleanup, which drains a bucket via list_object_versions before deleting it — saw an "empty" bucket, deleted nothing, then hit BucketNotEmpty on delete_bucket, cascading failures across the suite.

Changes:
- listObjects now detects V1 vs V2 (list-type=2), honors `marker` for V1, and emits a V1-shaped result (<Marker>/<NextMarker>, no KeyCount) or the V2 shape accordingly. S3Xml.listBucket split into listBucketV1/listBucketV2.
- New LIST_OBJECT_VERSIONS route + handler: lists each object as its sole latest <Version> with the literal "null" version id (S3's unversioned convention), paginated by key-marker. New S3Xml.listVersions.
- Shared rollUp() / writeContents() / writeCommonPrefixes() helpers.

Both were listed as in-scope in S3_GATEWAY_PLAN.md §7 ("V1 `marker` compatibility"). Verified end-to-end against a from-source gateway: v1 marker paging works and the full list_object_versions -> delete_objects -> delete_bucket cleanup now drains and removes a bucket.