### PR TITLE
Add server + client integration tests (UT+IT coverage > 90%)

### DIFF
--- a/candybox-client/src/test/java/me/predatorray/candybox/client/CandyboxCliTest.java
+++ b/candybox-client/src/test/java/me/predatorray/candybox/client/CandyboxCliTest.java
@@ -68,4 +68,16 @@ class CandyboxCliTest {
         assertThat(run("-s", "no-port", "list-boxes")).isEqualTo(2);
         assertThat(stderr()).contains("Invalid --server");
     }
+
+    @Test
+    void serverOptionMissingValueAtEndIsRejected() {
+        assertThat(run("create-box", "my-box", "--server")).isEqualTo(2);
+        assertThat(stderr()).contains("Missing value for --server");
+    }
+
+    @Test
+    void helpAliasesPrintUsageAndSucceed() {
+        assertThat(run("-h")).isEqualTo(0);
+        assertThat(stdout()).contains("Usage: candybox");
+    }
 }

--- a/candybox-client/src/test/java/me/predatorray/candybox/client/ClusterRouterTest.java
+++ b/candybox-client/src/test/java/me/predatorray/candybox/client/ClusterRouterTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import me.predatorray.candybox.common.SystemClock;
+import me.predatorray.candybox.common.exception.CandyboxException;
 import me.predatorray.candybox.common.exception.NotOwnerException;
 import me.predatorray.candybox.coordination.CandyboxKeys;
 import me.predatorray.candybox.coordination.fake.InMemoryCoordinationService;
@@ -125,6 +126,107 @@ class ClusterRouterTest {
             Message resp = router.callAny(new Message.CreateBoxRequest("new-box"));
             assertThat(resp).isInstanceOf(Message.OkResponse.class);
             assertThat(transport.contacted).hasSize(1);
+        }
+    }
+
+    @Test
+    void callAnyThrowsWhenThereAreNoMembers() {
+        InMemoryCoordinationService coordination = new InMemoryCoordinationService(); // no members
+        RecordingTransport transport = new RecordingTransport();
+        try (ClusterRouter router = new ClusterRouter(transport, coordination, 5_000, SystemClock.INSTANCE)) {
+            assertThatThrownBy(() -> router.callAny(new Message.ListBoxesRequest()))
+                    .isInstanceOf(CandyboxException.class)
+                    .hasMessageContaining("No cluster members");
+        }
+    }
+
+    @Test
+    void throwsWhenOwnerNodeIsNotRegistered() {
+        InMemoryCoordinationService coordination = coordinationWithMembers();
+        coordination.tryAcquireLease(CandyboxKeys.ownerResource("b"), 99, 10_000); // node 99 unknown
+        RecordingTransport transport = new RecordingTransport();
+        try (ClusterRouter router = new ClusterRouter(transport, coordination, 5_000, SystemClock.INSTANCE)) {
+            assertThatThrownBy(() -> router.callBox("b", new Message.GetCandyRequest("b", "k")))
+                    .isInstanceOf(NotOwnerException.class)
+                    .hasMessageContaining("not registered");
+        }
+    }
+
+    @Test
+    void throwsOnUnparseableMemberAddress() {
+        InMemoryCoordinationService coordination = new InMemoryCoordinationService();
+        coordination.registerMember(5, "no-colon-here".getBytes(StandardCharsets.UTF_8));
+        coordination.tryAcquireLease(CandyboxKeys.ownerResource("b"), 5, 10_000);
+        RecordingTransport transport = new RecordingTransport();
+        try (ClusterRouter router = new ClusterRouter(transport, coordination, 5_000, SystemClock.INSTANCE)) {
+            assertThatThrownBy(() -> router.callBox("b", new Message.GetCandyRequest("b", "k")))
+                    .isInstanceOf(NotOwnerException.class)
+                    .hasMessageContaining("Unroutable");
+        }
+    }
+
+    @Test
+    void exceedingRoutingAttemptsThrowsNotOwner() {
+        InMemoryCoordinationService coordination = coordinationWithMembers();
+        coordination.tryAcquireLease(CandyboxKeys.ownerResource("b"), 2, 10_000);
+        // A transport that always redirects: the router exhausts MAX_ATTEMPTS and gives up.
+        Transport alwaysMoved = new Transport() {
+            @Override
+            public Connection connect(String host, int port) {
+                return new Connection() {
+                    @Override
+                    public Frame call(Frame request) {
+                        return CODEC.encode(new Message.MovedResponse(2));
+                    }
+
+                    @Override
+                    public void close() {
+                    }
+                };
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        try (ClusterRouter router = new ClusterRouter(alwaysMoved, coordination, 5_000, SystemClock.INSTANCE)) {
+            assertThatThrownBy(() -> router.callBox("b", new Message.GetCandyRequest("b", "k")))
+                    .isInstanceOf(NotOwnerException.class)
+                    .hasMessageContaining("exceeded routing attempts");
+        }
+    }
+
+    @Test
+    void brokenConnectionIsDroppedAndReopenedOnRetry() {
+        InMemoryCoordinationService coordination = coordinationWithMembers();
+        coordination.tryAcquireLease(CandyboxKeys.ownerResource("b"), 2, 10_000);
+        // First call on each freshly-opened connection throws; the router must drop it and rethrow.
+        Transport flaky = new Transport() {
+            @Override
+            public Connection connect(String host, int port) {
+                return new Connection() {
+                    @Override
+                    public Frame call(Frame request) {
+                        throw new IllegalStateException("connection reset");
+                    }
+
+                    @Override
+                    public void close() {
+                    }
+                };
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        try (ClusterRouter router = new ClusterRouter(flaky, coordination, 5_000, SystemClock.INSTANCE)) {
+            assertThatThrownBy(() -> router.callBox("b", new Message.GetCandyRequest("b", "k")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("connection reset");
+            // A subsequent call reopens the connection and fails the same way (not a stale-handle error).
+            assertThatThrownBy(() -> router.callBox("b", new Message.GetCandyRequest("b", "k")))
+                    .isInstanceOf(IllegalStateException.class);
         }
     }
 }

--- a/candybox-common/src/test/java/me/predatorray/candybox/common/HybridLogicalClockTest.java
+++ b/candybox-common/src/test/java/me/predatorray/candybox/common/HybridLogicalClockTest.java
@@ -91,4 +91,38 @@ class HybridLogicalClockTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("skew");
     }
+
+    @Test
+    void constructorRejectsNegativeSkewBound() {
+        assertThatThrownBy(() -> new HybridLogicalClock(1, new ManualClock(0), -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxAcceptableSkewMillis");
+    }
+
+    @Test
+    void peekReportsTheLatestStampWithoutAdvancing() {
+        ManualClock clock = new ManualClock(1000);
+        HybridLogicalClock hlc = new HybridLogicalClock(3, clock, 60_000);
+        assertThat(hlc.nodeId()).isEqualTo(3);
+
+        Hlc ticked = hlc.tick();
+        Hlc first = hlc.peek();
+        Hlc second = hlc.peek();
+        // peek() is idempotent and equal to the last issued stamp.
+        assertThat(first).isEqualTo(ticked);
+        assertThat(second).isEqualTo(first);
+        // ...and the next tick still advances past it.
+        assertThat(hlc.tick()).isGreaterThan(first);
+    }
+
+    @Test
+    void observeWithinSkewButNotAheadLeavesClockUnchanged() {
+        ManualClock clock = new ManualClock(1000);
+        HybridLogicalClock hlc = new HybridLogicalClock(1, clock, 60_000);
+        Hlc current = hlc.tick(); // physical=1000, logical=0
+
+        // An older observed stamp must not move the clock backwards.
+        hlc.observe(new Hlc(500, 9, 0));
+        assertThat(hlc.peek()).isEqualTo(current);
+    }
 }

--- a/candybox-common/src/test/java/me/predatorray/candybox/common/PartTest.java
+++ b/candybox-common/src/test/java/me/predatorray/candybox/common/PartTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PartTest {
+
+    private static SegmentRef seg(long syrupId, long first, long last) {
+        return new SegmentRef(syrupId, first, last);
+    }
+
+    @Test
+    void entryCountSumsAcrossSegments() {
+        Part part = new Part(10, 4, 0x1234,
+                List.of(seg(1, 0, 2), seg(2, 0, 1))); // 3 + 2 = 5 entries
+        assertThat(part.entryCount()).isEqualTo(5);
+    }
+
+    @Test
+    void nullSegmentsBecomeEmptyForAZeroLengthPart() {
+        Part empty = new Part(0, 4, 0, null);
+        assertThat(empty.segments()).isEmpty();
+        assertThat(empty.entryCount()).isZero();
+    }
+
+    @Test
+    void segmentsAreDefensivelyCopiedAndImmutable() {
+        var source = new java.util.ArrayList<>(List.of(seg(1, 0, 0)));
+        Part part = new Part(5, 4, 0, source);
+        source.add(seg(9, 0, 0));
+        assertThat(part.segments()).hasSize(1);
+        assertThatThrownBy(() -> part.segments().add(seg(2, 0, 0)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void rejectsNegativePartLength() {
+        assertThatThrownBy(() -> new Part(-1, 4, 0, List.of(seg(1, 0, 0))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("partLength");
+    }
+
+    @Test
+    void rejectsNonPositiveChunkSize() {
+        assertThatThrownBy(() -> new Part(1, 0, 0, List.of(seg(1, 0, 0))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkSize");
+    }
+
+    @Test
+    void rejectsNonEmptyPartWithoutSegments() {
+        assertThatThrownBy(() -> new Part(5, 4, 0, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one segment");
+    }
+}

--- a/candybox-common/src/test/java/me/predatorray/candybox/common/config/CandyboxConfigTest.java
+++ b/candybox-common/src/test/java/me/predatorray/candybox/common/config/CandyboxConfigTest.java
@@ -120,4 +120,38 @@ class CandyboxConfigTest {
         builder.quorum(LedgerRole.WAL, new QuorumConfig(9, 9, 9));
         assertThat(cfg.quorum(LedgerRole.WAL)).isEqualTo(new QuorumConfig(3, 3, 2));
     }
+
+    @Test
+    void multipartTuningDefaultsAndOverrides() {
+        CandyboxConfig defaults = CandyboxConfig.defaults();
+        assertThat(defaults.multipartMinPartBytes()).isEqualTo(5L << 20);
+        assertThat(defaults.multipartMaxParts()).isEqualTo(10_000);
+        assertThat(defaults.multipartUploadTtlMillis()).isPositive();
+        assertThat(defaults.multipartMaxConcurrentUploadsPerBox()).isEqualTo(10_000);
+
+        CandyboxConfig cfg = CandyboxConfig.builder()
+                .multipartMinPartBytes(1024)
+                .multipartMaxParts(50)
+                .multipartUploadTtlMillis(123)
+                .multipartMaxConcurrentUploadsPerBox(7)
+                .build();
+        assertThat(cfg.multipartMinPartBytes()).isEqualTo(1024);
+        assertThat(cfg.multipartMaxParts()).isEqualTo(50);
+        assertThat(cfg.multipartUploadTtlMillis()).isEqualTo(123);
+        assertThat(cfg.multipartMaxConcurrentUploadsPerBox()).isEqualTo(7);
+    }
+
+    @Test
+    void buildRejectsNegativeMultipartMinPartBytes() {
+        assertThatThrownBy(() -> CandyboxConfig.builder().multipartMinPartBytes(-1).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("multipartMinPartBytes");
+    }
+
+    @Test
+    void buildRejectsNonPositiveMultipartMaxParts() {
+        assertThatThrownBy(() -> CandyboxConfig.builder().multipartMaxParts(0).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("multipartMaxParts");
+    }
 }

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/client/CandyboxCliIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/client/CandyboxCliIT.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import me.predatorray.candybox.bookkeeper.bk.BookKeeperLedgerStore;
+import me.predatorray.candybox.common.SystemClock;
+import me.predatorray.candybox.common.config.CandyboxConfig;
+import me.predatorray.candybox.coordination.zk.ZooKeeperCoordinationService;
+import me.predatorray.candybox.it.EmbeddedBookKeeper;
+import me.predatorray.candybox.protocol.FrameCodec;
+import me.predatorray.candybox.protocol.transport.TcpTransportServer;
+import me.predatorray.candybox.server.CandyboxNode;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Drives {@link CandyboxCli} (the {@code candybox} command-line front end) against a live node over
+ * TCP, embedded BookKeeper, and in-process ZooKeeper. Complements {@code CandyboxCliTest}, which only
+ * covers the argument-handling paths that resolve before a network call. Lives in the
+ * {@code me.predatorray.candybox.client} package so it can invoke the package-private
+ * {@link CandyboxCli#run(String[], PrintStream, PrintStream)} entry point.
+ */
+class CandyboxCliIT {
+
+    private static EmbeddedBookKeeper bookKeeper;
+    private static TestingServer zookeeper;
+    private static CandyboxNode node;
+    private static TcpTransportServer transportServer;
+    private static ZooKeeperCoordinationService nodeCoord;
+    private static BookKeeperLedgerStore store;
+    private static String server;
+
+    @BeforeAll
+    static void start() throws Exception {
+        bookKeeper = new EmbeddedBookKeeper(3);
+        zookeeper = new TestingServer(true);
+
+        CandyboxConfig config = CandyboxConfig.builder().leaseRenewIntervalMillis(0).build();
+        int port = freePort();
+        store = new BookKeeperLedgerStore(bookKeeper.clientConfiguration(),
+                "candybox".getBytes(StandardCharsets.UTF_8));
+        nodeCoord = new ZooKeeperCoordinationService(zookeeper.getConnectString(), SystemClock.INSTANCE);
+        node = new CandyboxNode(1, config, store, nodeCoord, SystemClock.INSTANCE, "127.0.0.1:" + port);
+        transportServer = new TcpTransportServer(port, node.requestHandler(), new FrameCodec());
+        server = "127.0.0.1:" + port;
+    }
+
+    @AfterAll
+    static void stop() {
+        closeQuietly(transportServer);
+        closeQuietly(node);
+        closeQuietly(nodeCoord);
+        closeQuietly(store);
+        if (zookeeper != null) {
+            closeQuietly(zookeeper::close);
+        }
+        if (bookKeeper != null) {
+            closeQuietly(bookKeeper::close);
+        }
+    }
+
+    // ---- the CLI run, with stdout/stderr captured -----------------------------------------
+
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+    /** Invokes the CLI with the test server prepended; returns the process exit code. */
+    private int cli(String... args) {
+        // Reset the capture buffers so stdout()/stderr() reflect only this invocation.
+        out.reset();
+        err.reset();
+        String[] full = new String[args.length + 2];
+        full[0] = "-s";
+        full[1] = server;
+        System.arraycopy(args, 0, full, 2, args.length);
+        return CandyboxCli.run(full, new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+    }
+
+    private String stdout() {
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private byte[] stdoutBytes() {
+        return out.toByteArray();
+    }
+
+    private String stderr() {
+        return err.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void boxCommands() {
+        assertThat(cli("create-box", "cli-boxes")).isZero();
+        assertThat(cli("head-box", "cli-boxes")).isZero();
+        assertThat(stdout()).contains("exists");
+        assertThat(cli("list-boxes")).isZero();
+        assertThat(stdout()).contains("cli-boxes");
+        assertThat(cli("delete-box", "cli-boxes", "--force")).isZero();
+    }
+
+    @Test
+    void headBoxAbsentReturnsNonZero() {
+        assertThat(cli("head-box", "never-created-box")).isEqualTo(1);
+        assertThat(stdout()).contains("absent");
+    }
+
+    @Test
+    void putGetHeadDelete(@TempDir Path tmp) throws IOException {
+        assertThat(cli("create-box", "cli-crud")).isZero();
+        Path input = tmp.resolve("in.txt");
+        byte[] payload = "command-line candy".getBytes(StandardCharsets.UTF_8);
+        Files.write(input, payload);
+
+        assertThat(cli("put", "cli-crud", "obj", input.toString(),
+                "--content-type", "text/plain", "--meta", "owner=cli")).isZero();
+
+        // get to stdout returns the exact bytes
+        assertThat(cli("get", "cli-crud", "obj")).isZero();
+        assertThat(stdoutBytes()).isEqualTo(payload);
+
+        // get to a file
+        Path output = tmp.resolve("out.txt");
+        assertThat(cli("get", "cli-crud", "obj", output.toString())).isZero();
+        assertThat(Files.readAllBytes(output)).isEqualTo(payload);
+
+        // head prints metadata
+        assertThat(cli("head", "cli-crud", "obj")).isZero();
+        assertThat(stdout())
+                .contains("contentLength: " + payload.length)
+                .contains("contentType:   text/plain")
+                .contains("meta.owner: cli");
+
+        assertThat(cli("delete", "cli-crud", "obj")).isZero();
+    }
+
+    @Test
+    void copyAndRename(@TempDir Path tmp) throws IOException {
+        assertThat(cli("create-box", "cli-copy")).isZero();
+        Path input = tmp.resolve("src.bin");
+        Files.write(input, "zero-copy".getBytes(StandardCharsets.UTF_8));
+        assertThat(cli("put", "cli-copy", "src", input.toString())).isZero();
+
+        assertThat(cli("copy", "cli-copy", "src", "dst")).isZero();
+        assertThat(cli("rename", "cli-copy", "src", "moved")).isZero();
+
+        // dst (copy) and moved (rename target) both readable
+        assertThat(cli("get", "cli-copy", "dst")).isZero();
+        assertThat(stdoutBytes()).isEqualTo("zero-copy".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void listAndDeleteRange(@TempDir Path tmp) throws IOException {
+        assertThat(cli("create-box", "cli-list")).isZero();
+        Path input = tmp.resolve("v");
+        Files.write(input, "x".getBytes(StandardCharsets.UTF_8));
+        for (String k : new String[] {"p/1", "p/2", "p/3"}) {
+            assertThat(cli("put", "cli-list", k, input.toString())).isZero();
+        }
+
+        assertThat(cli("list", "cli-list", "p/", "--max", "2")).isZero();
+        String listing = stdout();
+        assertThat(listing).contains("p/1").contains("p/2");
+        // page of 2 of 3 entries is truncated, so the CLI prints the continuation hint
+        assertThat(listing).contains("truncated");
+
+        // positional-prefix range delete removes the whole p/ range
+        assertThat(cli("delete-range", "cli-list", "p/")).isZero();
+        assertThat(cli("list", "cli-list", "p/")).isZero();
+        assertThat(stdout()).doesNotContain("p/1");
+    }
+
+    @Test
+    void unknownCommandPrintsUsageWithExitCodeTwo() {
+        assertThat(cli("frobnicate")).isEqualTo(2);
+        assertThat(stderr()).contains("Unknown command: frobnicate");
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------
+
+    private static int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) {
+            return;
+        }
+        try {
+            c.close();
+        } catch (Exception ignored) {
+            // best effort
+        }
+    }
+}

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/client/CandyboxCliIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/client/CandyboxCliIT.java
@@ -201,6 +201,33 @@ class CandyboxCliIT {
         assertThat(stderr()).contains("Unknown command: frobnicate");
     }
 
+    @Test
+    void getOfMissingKeyFailsWithErrorExitCode() {
+        assertThat(cli("create-box", "cli-missing")).isZero();
+        assertThat(cli("get", "cli-missing", "absent")).isEqualTo(1);
+        assertThat(stderr()).contains("error:");
+    }
+
+    @Test
+    void deleteRangeWindowFormAndListOptions(@TempDir Path tmp) throws IOException {
+        assertThat(cli("create-box", "cli-range")).isZero();
+        Path v = tmp.resolve("v");
+        Files.write(v, "x".getBytes(StandardCharsets.UTF_8));
+        for (String k : new String[] {"r1", "r2", "r3", "r4"}) {
+            assertThat(cli("put", "cli-range", k, v.toString())).isZero();
+        }
+
+        // Reverse listing with an explicit window and start-after, exercising the option parser.
+        assertThat(cli("list", "cli-range", "--reverse", "--start", "r1", "--end", "r4",
+                "--start-after", "r4")).isZero();
+
+        // Window-form range delete (no positional prefix; bounded by --start/--end).
+        assertThat(cli("delete-range", "cli-range", "--start", "r1", "--end", "r3")).isZero();
+        assertThat(cli("list", "cli-range", "r")).isZero();
+        // r1, r2 deleted; r3, r4 remain.
+        assertThat(stdout()).contains("r3").contains("r4").doesNotContain("r1");
+    }
+
     // ---- helpers ---------------------------------------------------------------------------
 
     private static int freePort() {

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/EmbeddedBookKeeper.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/EmbeddedBookKeeper.java
@@ -27,12 +27,12 @@ import org.apache.bookkeeper.util.LocalBookKeeper;
  * for the integration tests. No external services or Docker; everything runs in the test JVM and is
  * shut down by {@link #close()}.
  */
-final class EmbeddedBookKeeper implements AutoCloseable {
+public final class EmbeddedBookKeeper implements AutoCloseable {
 
     private final int zkPort;
     private final LocalBookKeeper localBookKeeper;
 
-    EmbeddedBookKeeper(int numBookies) {
+    public EmbeddedBookKeeper(int numBookies) {
         this.zkPort = freePort();
         try {
             ServerConfiguration serverConf = new ServerConfiguration();
@@ -49,12 +49,13 @@ final class EmbeddedBookKeeper implements AutoCloseable {
         awaitReady(numBookies);
     }
 
-    private String metadataServiceUri() {
+    /** The {@code zk://…/ledgers} metadata service URI for the embedded cluster. */
+    public String metadataServiceUri() {
         return "zk://127.0.0.1:" + zkPort + "/ledgers";
     }
 
     /** A client configuration pointing at the embedded cluster's metadata service. */
-    ClientConfiguration clientConfiguration() {
+    public ClientConfiguration clientConfiguration() {
         ClientConfiguration conf = new ClientConfiguration();
         conf.setMetadataServiceUri(metadataServiceUri());
         return conf;

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/ServerClientLifecycleIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/ServerClientLifecycleIT.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import me.predatorray.candybox.bookkeeper.bk.BookKeeperLedgerStore;
+import me.predatorray.candybox.client.CandyboxClient;
+import me.predatorray.candybox.common.BoxName;
+import me.predatorray.candybox.common.SystemClock;
+import me.predatorray.candybox.common.config.CandyboxConfig;
+import me.predatorray.candybox.common.exception.CandyNotFoundException;
+import me.predatorray.candybox.common.exception.CandyboxException;
+import me.predatorray.candybox.coordination.zk.ZooKeeperCoordinationService;
+import me.predatorray.candybox.protocol.FrameCodec;
+import me.predatorray.candybox.protocol.transport.TcpTransport;
+import me.predatorray.candybox.protocol.transport.TcpTransportServer;
+import me.predatorray.candybox.server.CandyboxNode;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the entire {@link CandyboxClient} surface against a real {@link CandyboxNode} over TCP,
+ * embedded BookKeeper, and in-process ZooKeeper. This is the end-to-end path that exercises the
+ * server-side {@code NodeRequestHandler} dispatch and the client's response decoding for every
+ * operation: Box lifecycle, single-object CRUD, range GET, copy/rename, range delete, listing
+ * (forward/reverse/paged), and the full multipart-upload flow. Single-node, single owner, so every
+ * request routes straight to the node that created the Box.
+ */
+class ServerClientLifecycleIT {
+
+    private static EmbeddedBookKeeper bookKeeper;
+    private static TestingServer zookeeper;
+
+    private static CandyboxNode node;
+    private static TcpTransportServer transportServer;
+    private static TcpTransport transport;
+    private static ZooKeeperCoordinationService nodeCoord;
+    private static ZooKeeperCoordinationService clientCoord;
+    private static BookKeeperLedgerStore store;
+    private static CandyboxClient client;
+
+    @BeforeAll
+    static void start() throws Exception {
+        bookKeeper = new EmbeddedBookKeeper(3);
+        zookeeper = new TestingServer(true);
+
+        // Drop the multipart minimum part size so the multipart tests can use tiny in-memory parts
+        // (the 5 MiB S3 default only matters for the non-final part; correctness is the same).
+        CandyboxConfig config = CandyboxConfig.builder()
+                .leaseRenewIntervalMillis(0)
+                .multipartMinPartBytes(0)
+                .build();
+        int port = freePort();
+        store = new BookKeeperLedgerStore(bookKeeper.clientConfiguration(), bytes("candybox"));
+        nodeCoord = new ZooKeeperCoordinationService(zookeeper.getConnectString(), SystemClock.INSTANCE);
+        node = new CandyboxNode(1, config, store, nodeCoord, SystemClock.INSTANCE, "127.0.0.1:" + port);
+        transportServer = new TcpTransportServer(port, node.requestHandler(), new FrameCodec());
+
+        transport = new TcpTransport();
+        clientCoord = new ZooKeeperCoordinationService(zookeeper.getConnectString(), SystemClock.INSTANCE);
+        client = new CandyboxClient(transport, clientCoord, config);
+    }
+
+    @AfterAll
+    static void stop() {
+        closeQuietly(client);
+        closeQuietly(transport);
+        closeQuietly(transportServer);
+        closeQuietly(node);
+        closeQuietly(nodeCoord);
+        closeQuietly(clientCoord);
+        closeQuietly(store);
+        if (zookeeper != null) {
+            closeQuietly(zookeeper::close);
+        }
+        if (bookKeeper != null) {
+            closeQuietly(bookKeeper::close);
+        }
+    }
+
+    @Test
+    void boxLifecycle() {
+        String box = "lifecycle-box";
+        assertThat(client.headBox(box)).isFalse();
+        client.createBox(box);
+        assertThat(client.headBox(box)).isTrue();
+        assertThat(client.listBoxes()).contains(box);
+
+        client.deleteBox(box, true);
+        assertThat(client.headBox(box)).isFalse();
+    }
+
+    @Test
+    void candyCrudAndHead() {
+        String box = "crud-box";
+        client.createBox(box);
+        byte[] data = bytes("hello candybox");
+        client.putCandy(box, "k/1", data, "text/plain", Map.of("owner", "alice"), "idem-1");
+
+        assertThat(client.getCandy(box, "k/1")).isEqualTo(data);
+
+        CandyboxClient.CandyInfo info = client.headCandy(box, "k/1");
+        assertThat(info.contentLength()).isEqualTo(data.length);
+        assertThat(info.contentType()).isEqualTo("text/plain");
+        assertThat(info.userMetadata()).containsEntry("owner", "alice");
+
+        // Streaming get convenience writes the same bytes.
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        client.getCandy(box, "k/1", out);
+        assertThat(out.toByteArray()).isEqualTo(data);
+
+        client.deleteCandy(box, "k/1");
+        assertThatThrownBy(() -> client.getCandy(box, "k/1"))
+                .isInstanceOf(CandyNotFoundException.class);
+    }
+
+    @Test
+    void rangeGet() {
+        String box = "range-box";
+        client.createBox(box);
+        byte[] data = bytes("0123456789");
+        client.putCandy(box, "blob", data, "application/octet-stream", Map.of(), null);
+
+        // Explicit inclusive window [2,5] -> "2345".
+        CandyboxClient.RangeBytes window = client.getCandyRange(box, "blob", 2, 5);
+        assertThat(new String(window.data(), StandardCharsets.UTF_8)).isEqualTo("2345");
+        assertThat(window.totalLength()).isEqualTo(10);
+        assertThat(window.sliceLength()).isEqualTo(4);
+
+        // From offset to end (lastByte < 0) -> "6789".
+        CandyboxClient.RangeBytes toEnd = client.getCandyRange(box, "blob", 6, -1);
+        assertThat(new String(toEnd.data(), StandardCharsets.UTF_8)).isEqualTo("6789");
+
+        // Suffix range (firstByte < 0) -> last 3 bytes "789".
+        CandyboxClient.RangeBytes suffix = client.getCandyRange(box, "blob", -1, 3);
+        assertThat(new String(suffix.data(), StandardCharsets.UTF_8)).isEqualTo("789");
+    }
+
+    @Test
+    void copyAndRename() {
+        String box = "copy-box";
+        client.createBox(box);
+        byte[] data = bytes("payload");
+        client.putCandy(box, "src", data, "text/plain", Map.of(), null);
+
+        CandyboxClient.CandyInfo copied = client.copyCandy(box, "src", "dst", null);
+        assertThat(copied.contentLength()).isEqualTo(data.length);
+        assertThat(client.getCandy(box, "dst")).isEqualTo(data);
+        // Source still present after a copy.
+        assertThat(client.getCandy(box, "src")).isEqualTo(data);
+
+        client.renameCandy(box, "src", "moved", null);
+        assertThat(client.getCandy(box, "moved")).isEqualTo(data);
+        // Source gone after a rename.
+        assertThatThrownBy(() -> client.getCandy(box, "src"))
+                .isInstanceOf(CandyNotFoundException.class);
+    }
+
+    @Test
+    void rangeDeleteByPrefixAndWindow() {
+        String box = "delete-box";
+        client.createBox(box);
+        for (String k : List.of("logs/a", "logs/b", "data/x", "data/y", "data/z")) {
+            client.putCandy(box, k, bytes(k), "text/plain", Map.of(), null);
+        }
+
+        client.deleteRangeByPrefix(box, "logs/");
+        assertThat(keysIn(box, "logs/")).isEmpty();
+
+        // Delete the half-open window [data/x, data/z): removes x and y, keeps z.
+        client.deleteRange(box, "data/x", "data/z");
+        assertThat(keysIn(box, "data/")).containsExactly("data/z");
+    }
+
+    @Test
+    void listForwardReverseRangeAndPaging() {
+        String box = "list-box";
+        client.createBox(box);
+        for (String k : List.of("k1", "k2", "k3", "k4", "k5")) {
+            client.putCandy(box, k, bytes(k), "text/plain", Map.of(), null);
+        }
+
+        // Forward, full listing.
+        CandyboxClient.Listing all = client.listCandies(box, "k", null, 100);
+        assertThat(all.entries().stream().map(CandyboxClient.Listing.Entry::key))
+                .containsExactly("k1", "k2", "k3", "k4", "k5");
+
+        // Forward, paged: first page of 2, then continue from nextStartAfter.
+        CandyboxClient.Listing page1 = client.listCandies(box, "k", null, 2);
+        assertThat(page1.entries()).hasSize(2);
+        assertThat(page1.isTruncated()).isTrue();
+        CandyboxClient.Listing page2 = client.listCandies(box, "k", page1.nextStartAfter(), 2);
+        assertThat(page2.entries().stream().map(CandyboxClient.Listing.Entry::key))
+                .containsExactly("k3", "k4");
+
+        // Reverse over the whole range.
+        CandyboxClient.Listing reverse = client.listCandies(box, null, null, null, null, true, 100);
+        assertThat(reverse.entries().stream().map(CandyboxClient.Listing.Entry::key))
+                .containsExactly("k5", "k4", "k3", "k2", "k1");
+
+        // Half-open window [k2, k4).
+        CandyboxClient.Listing windowed = client.listCandies(box, null, "k2", "k4", null, false, 100);
+        assertThat(windowed.entries().stream().map(CandyboxClient.Listing.Entry::key))
+                .containsExactly("k2", "k3");
+    }
+
+    @Test
+    void multipartUploadCompletes() {
+        String box = "mpart-box";
+        client.createBox(box);
+        String uploadId = client.createMultipartUpload(box, "big", "text/plain", Map.of("k", "v"));
+        assertThat(uploadId).isNotBlank();
+
+        CandyboxClient.PartUploadInfo p1 = client.uploadPart(box, "big", uploadId, 1, bytes("hello "));
+        CandyboxClient.PartUploadInfo p2 = client.uploadPart(box, "big", uploadId, 2, bytes("world"));
+
+        CandyboxClient.PartListing parts = client.listParts(box, "big", uploadId, 0, 100);
+        assertThat(parts.parts()).hasSize(2);
+
+        CandyboxClient.CandyInfo done = client.completeMultipartUpload(box, "big", uploadId,
+                List.of(p1, p2), null);
+        assertThat(done.contentLength()).isEqualTo("hello world".length());
+        assertThat(client.getCandy(box, "big")).isEqualTo(bytes("hello world"));
+    }
+
+    @Test
+    void multipartListsThenAborts() {
+        String box = "abort-box";
+        client.createBox(box);
+        String uploadId = client.createMultipartUpload(box, "pending", null, Map.of());
+
+        CandyboxClient.MultipartListing inflight = client.listMultipartUploads(box, null, null, null, 100);
+        assertThat(inflight.uploads().stream().map(CandyboxClient.UploadEntry::uploadId))
+                .contains(uploadId);
+
+        client.abortMultipartUpload(box, "pending", uploadId);
+        // Abort is idempotent: a second abort is a no-op.
+        client.abortMultipartUpload(box, "pending", uploadId);
+
+        CandyboxClient.MultipartListing afterAbort =
+                client.listMultipartUploads(box, null, null, null, 100);
+        assertThat(afterAbort.uploads().stream().map(CandyboxClient.UploadEntry::uploadId))
+                .doesNotContain(uploadId);
+    }
+
+    @Test
+    void multipartUploadPartCopyFromExistingObject() {
+        String box = "mpcopy-box";
+        client.createBox(box);
+        byte[] source = bytes("abcdefghij");
+        client.putCandy(box, "source", source, "application/octet-stream", Map.of(), null);
+
+        String uploadId = client.createMultipartUpload(box, "assembled", null, Map.of());
+        // Copy the whole source as part 1, and a byte window [0,4] ("abcde") as part 2.
+        CandyboxClient.PartUploadInfo whole =
+                client.uploadPartCopy(box, "assembled", uploadId, 1, "source", -1, -1);
+        CandyboxClient.PartUploadInfo slice =
+                client.uploadPartCopy(box, "assembled", uploadId, 2, "source", 0, 4);
+
+        CandyboxClient.CandyInfo done = client.completeMultipartUpload(box, "assembled", uploadId,
+                List.of(whole, slice), null);
+        assertThat(done.contentLength()).isEqualTo(source.length + 5);
+        assertThat(client.getCandy(box, "assembled")).isEqualTo(bytes("abcdefghijabcde"));
+    }
+
+    @Test
+    void headBoxIsFalseForUnknownBoxAndMissingKeyGetFails() {
+        assertThat(client.headBox("ghost-box")).isFalse();
+        assertThatThrownBy(() -> client.getCandy("ghost-box", "k"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void serverErrorsSurfaceToTheClient() {
+        String box = "error-box";
+        client.createBox(box);
+
+        // Re-creating an existing Box is a server-side error mapped to an ErrorResponse.
+        assertThatThrownBy(() -> client.createBox(box))
+                .isInstanceOf(CandyboxException.class);
+
+        // An out-of-bounds range GET is rejected as an InvalidRange validation error.
+        client.putCandy(box, "small", bytes("0123456789"), "text/plain", Map.of(), null);
+        assertThatThrownBy(() -> client.getCandyRange(box, "small", 100, 200))
+                .isInstanceOf(CandyboxException.class);
+    }
+
+    @Test
+    void nodeMaintenanceOperationsRunOverOwnedBoxes() {
+        // Drive enough churn through a Box that the maintenance passes have real work to do.
+        String box = "maint-box";
+        client.createBox(box);
+        for (int i = 0; i < 8; i++) {
+            client.putCandy(box, "k" + i, bytes("v" + i), "text/plain", Map.of(), null);
+        }
+        client.deleteCandy(box, "k0");
+        // An in-flight multipart upload gives the stale-upload sweep something to consider.
+        client.createMultipartUpload(box, "pending", null, Map.of());
+
+        BoxName boxName = BoxName.of(box);
+        assertThat(node.boxExists(boxName)).isTrue();
+        assertThat(node.currentOwner(boxName)).contains(node.nodeId());
+        assertThat(node.listBoxes()).contains(box);
+        assertThat(node.ownedBoxStats()).containsKey(box);
+
+        // The three periodic maintenance passes should run without error and report a non-negative
+        // count of units processed.
+        assertThat(node.compactOwnedBoxesOnce()).isGreaterThanOrEqualTo(0);
+        assertThat(node.collectGarbageOnce()).isGreaterThanOrEqualTo(0);
+        assertThat(node.sweepStaleMultipartUploadsOnce()).isGreaterThanOrEqualTo(0);
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------
+
+    private static List<String> keysIn(String box, String prefix) {
+        return client.listCandies(box, prefix, null, 100).entries().stream()
+                .map(CandyboxClient.Listing.Entry::key)
+                .toList();
+    }
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) {
+            return;
+        }
+        try {
+            c.close();
+        } catch (Exception ignored) {
+            // best effort
+        }
+    }
+}

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/ServerClientLifecycleIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/it/ServerClientLifecycleIT.java
@@ -309,6 +309,38 @@ class ServerClientLifecycleIT {
     }
 
     @Test
+    void deleteBoxRequiresForceWhenNonEmptyThenSucceeds() {
+        String box = "nonempty-box";
+        client.createBox(box);
+        client.putCandy(box, "k", bytes("v"), "text/plain", Map.of(), null);
+
+        // A non-empty Box cannot be deleted without force.
+        assertThatThrownBy(() -> client.deleteBox(box, false))
+                .isInstanceOf(CandyboxException.class);
+        assertThat(client.headBox(box)).isTrue();
+
+        // Forced delete removes it.
+        client.deleteBox(box, true);
+        assertThat(client.headBox(box)).isFalse();
+    }
+
+    @Test
+    void boxOwnershipReleaseAndReopenReplaysState() {
+        String box = "handover-box";
+        client.createBox(box);
+        client.putCandy(box, "durable", bytes("survives-handover"), "text/plain", Map.of(), null);
+
+        BoxName boxName = BoxName.of(box);
+        // Hand the Box off this node and re-acquire it: the open path fences prior owners and replays
+        // the WAL, so the previously written value must still be readable.
+        node.releaseBox(boxName);
+        node.openBox(boxName);
+
+        assertThat(node.currentOwner(boxName)).contains(node.nodeId());
+        assertThat(client.getCandy(box, "durable")).isEqualTo(bytes("survives-handover"));
+    }
+
+    @Test
     void nodeMaintenanceOperationsRunOverOwnedBoxes() {
         // Drive enough churn through a Box that the maintenance passes have real work to do.
         String box = "maint-box";

--- a/candybox-integration-tests/src/test/java/me/predatorray/candybox/server/CandyboxServerIT.java
+++ b/candybox-integration-tests/src/test/java/me/predatorray/candybox/server/CandyboxServerIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import me.predatorray.candybox.client.CandyboxClient;
+import me.predatorray.candybox.it.EmbeddedBookKeeper;
+import me.predatorray.candybox.protocol.transport.TcpTransport;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Boots a full Candybox node through its process entrypoint {@link CandyboxServer#run(ServerConfig)} —
+ * loaded from a properties file via {@link ServerConfig#load} — against embedded BookKeeper and its
+ * in-process ZooKeeper. Verifies the composition root actually stands up: the health/metrics endpoint
+ * answers and the TCP server serves a real client round-trip. {@code run} blocks in the foreground, so
+ * it is driven on a daemon thread; the forked IT JVM's exit runs the registered shutdown hook. Lives
+ * in the {@code me.predatorray.candybox.server} package to reach the package-private {@code run}.
+ */
+class CandyboxServerIT {
+
+    private static EmbeddedBookKeeper bookKeeper;
+    private static TestingServer zookeeper;
+    private static int bindPort;
+    private static int healthPort;
+    private static Thread serverThread;
+    private static final AtomicReference<Throwable> serverFailure = new AtomicReference<>();
+
+    @BeforeAll
+    static void start(@TempDir Path tmp) throws Exception {
+        bookKeeper = new EmbeddedBookKeeper(3);
+        zookeeper = new TestingServer(true);
+        bindPort = freePort();
+        healthPort = freePort();
+
+        Path conf = tmp.resolve("candybox.properties");
+        Files.writeString(conf, String.join("\n",
+                "node.id=1",
+                // Coordination uses a dedicated ZooKeeper; ledger metadata lives in the embedded
+                // BookKeeper's own ZK, named explicitly so the two never share an ensemble.
+                "zookeeper.connect=" + zookeeper.getConnectString(),
+                "bookkeeper.metadataServiceUri=" + bookKeeper.metadataServiceUri(),
+                "server.bind=127.0.0.1:" + bindPort,
+                "server.advertised=127.0.0.1:" + bindPort,
+                "health.port=" + healthPort,
+                ""), StandardCharsets.UTF_8);
+
+        ServerConfig config = ServerConfig.load(conf);
+        serverThread = new Thread(() -> {
+            try {
+                CandyboxServer.run(config); // blocks until JVM shutdown
+            } catch (Throwable t) {
+                serverFailure.set(t);
+            }
+        }, "candybox-server-under-test");
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        awaitHealthy();
+    }
+
+    @AfterAll
+    static void stop() {
+        // run() owns its components and only releases them via its JVM shutdown hook, which fires when
+        // this forked IT JVM exits; we just tear down the embedded cluster here.
+        closeQuietly(zookeeper);
+        closeQuietly(bookKeeper);
+    }
+
+    private static void closeQuietly(AutoCloseable c) {
+        if (c == null) {
+            return;
+        }
+        try {
+            c.close();
+        } catch (Exception ignored) {
+            // best effort
+        }
+    }
+
+    @Test
+    void healthAndReadinessEndpointsAnswer() throws Exception {
+        assertThat(httpStatus("/healthz")).isEqualTo(200);
+        assertThat(httpStatus("/readyz")).isEqualTo(200);
+        assertThat(httpBody("/metrics")).contains("candybox_owned_boxes");
+    }
+
+    @Test
+    void bootstrappedNodeServesClientTraffic() {
+        try (TcpTransport transport = new TcpTransport();
+             CandyboxClient client = new CandyboxClient(transport, "127.0.0.1", bindPort)) {
+            client.createBox("server-it-box");
+            byte[] data = "via the process entrypoint".getBytes(StandardCharsets.UTF_8);
+            client.putCandy("server-it-box", "k", data, "text/plain", Map.of(), null);
+            assertThat(client.getCandy("server-it-box", "k")).isEqualTo(data);
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------------------------
+
+    private static void awaitHealthy() {
+        long deadline = System.currentTimeMillis() + 60_000;
+        while (System.currentTimeMillis() < deadline) {
+            Throwable failure = serverFailure.get();
+            if (failure != null) {
+                throw new IllegalStateException("Server failed to start", failure);
+            }
+            try {
+                if (httpStatus("/healthz") == 200) {
+                    return;
+                }
+            } catch (Exception notUpYet) {
+                // keep polling
+            }
+            sleep();
+        }
+        throw new IllegalStateException("Bootstrapped node did not become healthy in time");
+    }
+
+    private static int httpStatus(String path) throws Exception {
+        return send(path).statusCode();
+    }
+
+    private static String httpBody(String path) throws Exception {
+        return send(path).body();
+    }
+
+    private static HttpResponse<String> send(String path) throws Exception {
+        return HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + healthPort + path)).GET().build(),
+                BodyHandlers.ofString());
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static int freePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/candybox-protocol/src/test/java/me/predatorray/candybox/protocol/FrameCodecTest.java
+++ b/candybox-protocol/src/test/java/me/predatorray/candybox/protocol/FrameCodecTest.java
@@ -75,4 +75,33 @@ class FrameCodecTest {
                 .isInstanceOf(ProtocolException.class)
                 .hasMessageContaining("magic");
     }
+
+    @Test
+    void unsupportedVersionIsRejected() {
+        byte[] bytes = codec.encode(new Frame(Opcode.RESPONSE_OK, new byte[0]));
+        bytes[2] = 0x7F; // corrupt the version byte
+        assertThatThrownBy(() -> codec.decode(bytes))
+                .isInstanceOf(ProtocolException.class)
+                .hasMessageContaining("version");
+    }
+
+    @Test
+    void constructorRejectsNegativeMaxAndExposesTheCap() {
+        assertThatThrownBy(() -> new FrameCodec(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxFrameBytes");
+        assertThat(new FrameCodec(1234).maxFrameBytes()).isEqualTo(1234);
+    }
+
+    @Test
+    void writeAndReadOverStreamsRoundTrip() throws Exception {
+        Frame frame = new Frame(Opcode.GET_CANDY, "streamed".getBytes());
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        codec.write(out, frame);
+
+        // read(InputStream) wraps a non-DataInputStream, exercising that overload too.
+        Frame decoded = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertThat(decoded.opcode()).isEqualTo(Opcode.GET_CANDY);
+        assertThat(new String(decoded.payload())).isEqualTo("streamed");
+    }
 }

--- a/candybox-protocol/src/test/java/me/predatorray/candybox/protocol/MessageCodecTest.java
+++ b/candybox-protocol/src/test/java/me/predatorray/candybox/protocol/MessageCodecTest.java
@@ -235,4 +235,120 @@ class MessageCodecTest {
         assertThat(out.endKey()).isNull();
         assertThat(out.reverse()).isFalse();
     }
+
+    @Test
+    void multipartCreateAndUploadRequestsRoundTrip() {
+        Message.CreateMultipartUploadRequest create =
+                (Message.CreateMultipartUploadRequest) roundTrip(new Message.CreateMultipartUploadRequest(
+                        "box", "big", "text/plain", Map.of("k", "v")));
+        assertThat(create.key()).isEqualTo("big");
+        assertThat(create.contentType()).isEqualTo("text/plain");
+        assertThat(create.userMetadata()).containsEntry("k", "v");
+        assertThat(create.opcode()).isEqualTo(Opcode.CREATE_MULTIPART_UPLOAD);
+
+        // Null content-type should survive the round trip.
+        Message.CreateMultipartUploadRequest noType =
+                (Message.CreateMultipartUploadRequest) roundTrip(new Message.CreateMultipartUploadRequest(
+                        "box", "big", null, Map.of()));
+        assertThat(noType.contentType()).isNull();
+        assertThat(noType.userMetadata()).isEmpty();
+
+        Message.UploadPartRequest part = (Message.UploadPartRequest) roundTrip(
+                new Message.UploadPartRequest("box", "big", "upload-1", 3, "chunk".getBytes()));
+        assertThat(part.uploadId()).isEqualTo("upload-1");
+        assertThat(part.partNumber()).isEqualTo(3);
+        assertThat(new String(part.data())).isEqualTo("chunk");
+
+        Message.AbortMultipartUploadRequest abort = (Message.AbortMultipartUploadRequest) roundTrip(
+                new Message.AbortMultipartUploadRequest("box", "big", "upload-1"));
+        assertThat(abort.uploadId()).isEqualTo("upload-1");
+    }
+
+    @Test
+    void completeMultipartUploadRequestRoundTripsPartList() {
+        Message.CompleteMultipartUploadRequest req = new Message.CompleteMultipartUploadRequest(
+                "box", "big", "upload-7",
+                List.of(new Message.CompletedPart(1, 0x11), new Message.CompletedPart(2, 0x22)),
+                "idem-9");
+        Message.CompleteMultipartUploadRequest out =
+                (Message.CompleteMultipartUploadRequest) roundTrip(req);
+        assertThat(out.uploadId()).isEqualTo("upload-7");
+        assertThat(out.idempotencyToken()).isEqualTo("idem-9");
+        assertThat(out.parts()).hasSize(2);
+        assertThat(out.parts().get(1).partNumber()).isEqualTo(2);
+        assertThat(out.parts().get(1).crc32c()).isEqualTo(0x22);
+
+        // Null idempotency token and empty part list also round-trip.
+        Message.CompleteMultipartUploadRequest empty =
+                (Message.CompleteMultipartUploadRequest) roundTrip(new Message.CompleteMultipartUploadRequest(
+                        "box", "big", "upload-7", List.of(), null));
+        assertThat(empty.parts()).isEmpty();
+        assertThat(empty.idempotencyToken()).isNull();
+    }
+
+    @Test
+    void uploadPartCopyRequestRoundTripsRangeBounds() {
+        Message.UploadPartCopyRequest copy = (Message.UploadPartCopyRequest) roundTrip(
+                new Message.UploadPartCopyRequest("box", "dst", "upload-2", 4, "src", 10, 99));
+        assertThat(copy.srcKey()).isEqualTo("src");
+        assertThat(copy.partNumber()).isEqualTo(4);
+        assertThat(copy.firstByte()).isEqualTo(10);
+        assertThat(copy.lastByte()).isEqualTo(99);
+
+        // Open-ended copy (whole source) encoded as (-1, -1).
+        Message.UploadPartCopyRequest whole = (Message.UploadPartCopyRequest) roundTrip(
+                new Message.UploadPartCopyRequest("box", "dst", "upload-2", 1, "src", -1, -1));
+        assertThat(whole.firstByte()).isEqualTo(-1);
+        assertThat(whole.lastByte()).isEqualTo(-1);
+    }
+
+    @Test
+    void multipartListingRequestsRoundTrip() {
+        Message.ListMultipartUploadsRequest uploads =
+                (Message.ListMultipartUploadsRequest) roundTrip(new Message.ListMultipartUploadsRequest(
+                        "box", "p/", "key-m", "upload-m", 200));
+        assertThat(uploads.prefix()).isEqualTo("p/");
+        assertThat(uploads.keyMarker()).isEqualTo("key-m");
+        assertThat(uploads.uploadIdMarker()).isEqualTo("upload-m");
+        assertThat(uploads.maxUploads()).isEqualTo(200);
+
+        Message.ListPartsRequest parts = (Message.ListPartsRequest) roundTrip(
+                new Message.ListPartsRequest("box", "big", "upload-3", 5, 100));
+        assertThat(parts.uploadId()).isEqualTo("upload-3");
+        assertThat(parts.partNumberMarker()).isEqualTo(5);
+        assertThat(parts.maxParts()).isEqualTo(100);
+    }
+
+    @Test
+    void multipartResponsesRoundTrip() {
+        Message.CreateMultipartUploadResponse created =
+                (Message.CreateMultipartUploadResponse) roundTrip(
+                        new Message.CreateMultipartUploadResponse("upload-42"));
+        assertThat(created.uploadId()).isEqualTo("upload-42");
+
+        Message.UploadPartResponse part = (Message.UploadPartResponse) roundTrip(
+                new Message.UploadPartResponse(0xDEAD, 4096));
+        assertThat(part.crc32c()).isEqualTo(0xDEAD);
+        assertThat(part.partLength()).isEqualTo(4096);
+
+        Message.ListMultipartUploadsResponse uploads =
+                (Message.ListMultipartUploadsResponse) roundTrip(new Message.ListMultipartUploadsResponse(
+                        List.of(new Message.InProgressUpload("u1", "a", 100),
+                                new Message.InProgressUpload("u2", "b", 200)),
+                        "next-key", "next-upload"));
+        assertThat(uploads.uploads()).hasSize(2);
+        assertThat(uploads.uploads().get(0).uploadId()).isEqualTo("u1");
+        assertThat(uploads.nextKeyMarker()).isEqualTo("next-key");
+        assertThat(uploads.nextUploadIdMarker()).isEqualTo("next-upload");
+
+        Message.ListPartsResponse parts = (Message.ListPartsResponse) roundTrip(
+                new Message.ListPartsResponse(
+                        List.of(new Message.UploadedPart(1, 1024, 0x01),
+                                new Message.UploadedPart(2, 2048, 0x02)),
+                        7));
+        assertThat(parts.parts()).hasSize(2);
+        assertThat(parts.parts().get(1).partNumber()).isEqualTo(2);
+        assertThat(parts.parts().get(1).partLength()).isEqualTo(2048);
+        assertThat(parts.nextPartNumberMarker()).isEqualTo(7);
+    }
 }

--- a/candybox-server/src/test/java/me/predatorray/candybox/server/HealthServerTest.java
+++ b/candybox-server/src/test/java/me/predatorray/candybox/server/HealthServerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import me.predatorray.candybox.lsm.engine.BoxEngineStats;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the JDK-{@code HttpServer}-backed {@link HealthServer}: the {@code /healthz}, {@code /readyz}
+ * and {@code /metrics} endpoints, plus the Prometheus text rendering (labels, counters, gauge, and
+ * label escaping). No node or backends required — the readiness predicate and stats are supplied
+ * directly.
+ */
+class HealthServerTest {
+
+    private static BoxEngineStats stats(long puts, long gets) {
+        return new BoxEngineStats(puts, 0, gets, 0, 0, 0, 0, 0);
+    }
+
+    private static String get(int port, String path) throws Exception {
+        HttpClient http = HttpClient.newHttpClient();
+        return http.send(HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path)).GET().build(),
+                BodyHandlers.ofString()).body();
+    }
+
+    private static int status(int port, String path) throws Exception {
+        HttpClient http = HttpClient.newHttpClient();
+        return http.send(HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + path)).GET().build(),
+                BodyHandlers.ofString()).statusCode();
+    }
+
+    @Test
+    void healthzIsAlwaysOkAndReadyzFollowsThePredicate() throws Exception {
+        AtomicBoolean ready = new AtomicBoolean(false);
+        try (HealthServer server = new HealthServer(0, 1, ready::get, Map::of)) {
+            server.start();
+            int port = server.port();
+
+            assertThat(status(port, "/healthz")).isEqualTo(200);
+            assertThat(get(port, "/healthz")).contains("ok");
+
+            // Not ready yet -> 503.
+            assertThat(status(port, "/readyz")).isEqualTo(503);
+            assertThat(get(port, "/readyz")).contains("not ready");
+
+            // Flip readiness -> 200.
+            ready.set(true);
+            assertThat(status(port, "/readyz")).isEqualTo(200);
+            assertThat(get(port, "/readyz")).contains("ready");
+        }
+    }
+
+    @Test
+    void metricsEndpointRendersPerBoxCounters() throws Exception {
+        Map<String, BoxEngineStats> byBox = Map.of("photos", stats(3, 7));
+        try (HealthServer server = new HealthServer(0, 42, () -> true, () -> byBox)) {
+            server.start();
+            String body = get(server.port(), "/metrics");
+            assertThat(body)
+                    .contains("# TYPE candybox_puts_total counter")
+                    .contains("candybox_puts_total{node=\"42\",box=\"photos\"} 3")
+                    .contains("candybox_gets_total{node=\"42\",box=\"photos\"} 7")
+                    .contains("candybox_owned_boxes{node=\"42\"} 1");
+        }
+    }
+
+    @Test
+    void renderMetricsEscapesLabelSpecialCharacters() {
+        Map<String, BoxEngineStats> byBox = Map.of("a\"b\\c", stats(1, 0));
+        String rendered = HealthServer.renderMetrics(5, byBox);
+        // The box label's quote and backslash must be escaped for valid Prometheus exposition.
+        assertThat(rendered).contains("box=\"a\\\"b\\\\c\"");
+        assertThat(rendered).contains("candybox_owned_boxes{node=\"5\"} 1");
+    }
+
+    @Test
+    void renderMetricsWithNoBoxesStillEmitsTheGauge() {
+        String rendered = HealthServer.renderMetrics(9, Map.of());
+        assertThat(rendered).contains("candybox_owned_boxes{node=\"9\"} 0");
+        // The counter HELP/TYPE headers are present even with no series rows.
+        assertThat(rendered).contains("# TYPE candybox_compactions_total counter");
+    }
+}

--- a/candybox-server/src/test/java/me/predatorray/candybox/server/NodeRequestHandlerTest.java
+++ b/candybox-server/src/test/java/me/predatorray/candybox/server/NodeRequestHandlerTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.predatorray.candybox.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import me.predatorray.candybox.bookkeeper.fake.InMemoryLedgerStore;
+import me.predatorray.candybox.common.BoxName;
+import me.predatorray.candybox.common.ManualClock;
+import me.predatorray.candybox.common.config.CandyboxConfig;
+import me.predatorray.candybox.coordination.fake.InMemoryCoordinationService;
+import me.predatorray.candybox.protocol.Frame;
+import me.predatorray.candybox.protocol.Message;
+import me.predatorray.candybox.protocol.MessageCodec;
+import me.predatorray.candybox.protocol.Opcode;
+import me.predatorray.candybox.protocol.transport.RequestHandler;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the server-side request dispatcher {@link NodeRequestHandler} directly over the protocol
+ * codec, driving a real {@link CandyboxNode} backed by the in-memory {@code LedgerStore} /
+ * {@code CoordinationService} fakes (no BookKeeper, ZooKeeper or sockets). Focuses on the dispatch
+ * branches and error mappings that the socket-level integration tests do not deterministically reach:
+ * {@code MOVED} re-routing, not-found, malformed frames, validation errors and the multipart listing
+ * operations.
+ */
+class NodeRequestHandlerTest {
+
+    private static final MessageCodec CODEC = new MessageCodec();
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static Message roundTrip(RequestHandler handler, Message request) {
+        Frame response = handler.handle(CODEC.encode(request));
+        return CODEC.decode(response);
+    }
+
+    /** Multipart minimum dropped to 0 so small in-memory parts complete. */
+    private static CandyboxConfig config() {
+        return CandyboxConfig.builder().multipartMinPartBytes(0).build();
+    }
+
+    @Test
+    void malformedFrameMapsToProtocolError() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            // A frame whose body the codec cannot decode (a PUT opcode with a truncated payload) must
+            // come back as an ErrorResponse, not blow up the connection.
+            Frame garbage = new Frame(Opcode.PUT_CANDY, new byte[] {1, 2, 3, 4});
+            Message response = CODEC.decode(handler.handle(garbage));
+            assertThat(response).isInstanceOf(Message.ErrorResponse.class);
+            assertThat(((Message.ErrorResponse) response).errorType()).isEqualTo("ProtocolError");
+        }
+    }
+
+    @Test
+    void requestForUnknownBoxIsNotFound() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            // No node owns "absent-box": a Box-routed request resolves to NotFound (no other owner).
+            assertThat(roundTrip(handler, new Message.GetCandyRequest("absent-box", "k")))
+                    .isInstanceOf(Message.NotFoundResponse.class);
+            assertThat(roundTrip(handler, new Message.HeadBoxRequest("absent-box")))
+                    .isInstanceOf(Message.NotFoundResponse.class);
+        }
+    }
+
+    @Test
+    void requestForBoxOwnedElsewhereIsRedirectedWithMoved() {
+        // Two nodes sharing one coordination service and store: node 1 owns the Box, so a request to
+        // node 2 must come back as MOVED(1) — the re-route signal the client follows.
+        InMemoryLedgerStore store = new InMemoryLedgerStore();
+        InMemoryCoordinationService coordination = new InMemoryCoordinationService();
+        try (CandyboxNode owner = new CandyboxNode(1, config(), store, coordination, new ManualClock(1000));
+             CandyboxNode other = new CandyboxNode(2, config(), store, coordination, new ManualClock(1000))) {
+            owner.createBox(BoxName.of("shared-box"));
+
+            Message response = roundTrip(other.requestHandler(),
+                    new Message.GetCandyRequest("shared-box", "k"));
+            assertThat(response).isInstanceOf(Message.MovedResponse.class);
+            assertThat(((Message.MovedResponse) response).ownerNodeId()).isEqualTo(1);
+        }
+        store.close();
+    }
+
+    @Test
+    void duplicateCreateBoxAndNonEmptyDeleteMapToErrorResponses() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            assertThat(roundTrip(handler, new Message.CreateBoxRequest("dup-box")))
+                    .isInstanceOf(Message.OkResponse.class);
+            // Re-create is a typed CandyboxException -> ErrorResponse.
+            assertThat(roundTrip(handler, new Message.CreateBoxRequest("dup-box")))
+                    .isInstanceOf(Message.ErrorResponse.class);
+
+            roundTrip(handler, new Message.PutCandyRequest("dup-box", "k", null, Map.of(), null,
+                    bytes("v")));
+            // Non-empty Box without force -> ErrorResponse (BoxNotEmpty).
+            assertThat(roundTrip(handler, new Message.DeleteBoxRequest("dup-box", false)))
+                    .isInstanceOf(Message.ErrorResponse.class);
+            // With force -> OK.
+            assertThat(roundTrip(handler, new Message.DeleteBoxRequest("dup-box", true)))
+                    .isInstanceOf(Message.OkResponse.class);
+        }
+    }
+
+    @Test
+    void invalidRangeGetMapsToErrorResponse() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            roundTrip(handler, new Message.CreateBoxRequest("range-box"));
+            roundTrip(handler, new Message.PutCandyRequest("range-box", "k", null, Map.of(), null,
+                    bytes("0123456789")));
+
+            Message response = roundTrip(handler,
+                    new Message.RangeGetCandyRequest("range-box", "k", 100, 200));
+            assertThat(response).isInstanceOf(Message.ErrorResponse.class);
+        }
+    }
+
+    @Test
+    void listingAndMaintenanceCandyOperationsDispatch() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            roundTrip(handler, new Message.CreateBoxRequest("ops-box"));
+            for (String k : List.of("a", "b", "c")) {
+                roundTrip(handler, new Message.PutCandyRequest("ops-box", k, null, Map.of(), null,
+                        bytes(k)));
+            }
+
+            // ListBoxes (cluster-wide-ish: this node's owned Boxes).
+            Message boxes = roundTrip(handler, new Message.ListBoxesRequest());
+            assertThat(((Message.ListBoxesResponse) boxes).boxes()).contains("ops-box");
+
+            // Reverse, ranged listing exercises the toScanQuery direction/bounds mapping.
+            Message listed = roundTrip(handler, new Message.ListCandiesRequest("ops-box", null, null,
+                    100, "a", "c", true));
+            assertThat(listed).isInstanceOf(Message.ListCandiesResponse.class);
+
+            // Copy then rename round-trips through HeadCandyResponse.
+            assertThat(roundTrip(handler, new Message.CopyCandyRequest("ops-box", "a", "a-copy", null)))
+                    .isInstanceOf(Message.HeadCandyResponse.class);
+            assertThat(roundTrip(handler, new Message.RenameCandyRequest("ops-box", "b", "b-moved", null)))
+                    .isInstanceOf(Message.HeadCandyResponse.class);
+
+            // Range delete (window form) returns OK.
+            assertThat(roundTrip(handler, new Message.DeleteRangeRequest("ops-box", null, "a", "c")))
+                    .isInstanceOf(Message.OkResponse.class);
+        }
+    }
+
+    @Test
+    void multipartDispatchIncludingListings() {
+        try (CandyboxNode node = new CandyboxNode(1, config(), new InMemoryLedgerStore(),
+                new InMemoryCoordinationService(), new ManualClock(1000))) {
+            RequestHandler handler = node.requestHandler();
+            roundTrip(handler, new Message.CreateBoxRequest("mp-box"));
+
+            Message created = roundTrip(handler, new Message.CreateMultipartUploadRequest(
+                    "mp-box", "obj", "text/plain", Map.of()));
+            String uploadId = ((Message.CreateMultipartUploadResponse) created).uploadId();
+
+            Message up1 = roundTrip(handler,
+                    new Message.UploadPartRequest("mp-box", "obj", uploadId, 1, bytes("hello ")));
+            Message up2 = roundTrip(handler,
+                    new Message.UploadPartRequest("mp-box", "obj", uploadId, 2, bytes("world")));
+            int crc1 = ((Message.UploadPartResponse) up1).crc32c();
+            int crc2 = ((Message.UploadPartResponse) up2).crc32c();
+
+            // ListParts and ListMultipartUploads dispatch.
+            Message parts = roundTrip(handler,
+                    new Message.ListPartsRequest("mp-box", "obj", uploadId, 0, 100));
+            assertThat(((Message.ListPartsResponse) parts).parts()).hasSize(2);
+
+            Message uploads = roundTrip(handler, new Message.ListMultipartUploadsRequest(
+                    "mp-box", null, null, null, 100));
+            assertThat(((Message.ListMultipartUploadsResponse) uploads).uploads()).hasSize(1);
+
+            // Complete and read back the assembled object.
+            Message done = roundTrip(handler, new Message.CompleteMultipartUploadRequest("mp-box", "obj",
+                    uploadId, List.of(new Message.CompletedPart(1, crc1), new Message.CompletedPart(2, crc2)),
+                    null));
+            assertThat(done).isInstanceOf(Message.HeadCandyResponse.class);
+            Message get = roundTrip(handler, new Message.GetCandyRequest("mp-box", "obj"));
+            assertThat(new String(((Message.CandyDataResponse) get).data(), StandardCharsets.UTF_8))
+                    .isEqualTo("hello world");
+
+            // A fresh upload that we then abort exercises the abort dispatch path.
+            Message created2 = roundTrip(handler, new Message.CreateMultipartUploadRequest(
+                    "mp-box", "obj2", null, Map.of()));
+            String upload2 = ((Message.CreateMultipartUploadResponse) created2).uploadId();
+            assertThat(roundTrip(handler, new Message.AbortMultipartUploadRequest("mp-box", "obj2", upload2)))
+                    .isInstanceOf(Message.OkResponse.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **server and client integration tests** that drive the full stack over real TCP, embedded BookKeeper, and in-process ZooKeeper, plus targeted unit tests for untested pure-logic paths. This lifts the combined **UT + IT aggregate coverage past 90%**.

**No production code changes** — only new/extended tests, and a visibility bump on the `EmbeddedBookKeeper` test helper so it can be shared across test packages.

## New integration tests (`candybox-integration-tests`)
- **`ServerClientLifecycleIT`** — drives the entire `CandyboxClient` API against a live `CandyboxNode`: Box lifecycle, single-object CRUD, range GET (window/suffix/to-end), copy/rename, range delete (prefix + window), listing (forward/reverse/paged), the full multipart-upload flow (create → uploadPart → listParts → complete, abort, uploadPartCopy, listMultipartUploads), server-side error mapping, and the periodic compaction/GC/stale-upload-sweep passes.
- **`CandyboxCliIT`** — runs the `candybox` CLI end-to-end against a live node (create/put/get/head/list/copy/rename/delete/delete-range/head-box, stdout + file output).
- **`CandyboxServerIT`** — boots a node through the `CandyboxServer` process entrypoint via `ServerConfig.load`, asserting the health/readiness/metrics endpoints answer and the bootstrapped node serves real client traffic.

## New / extended unit tests
- **`MessageCodecTest`** — round-trip coverage for the Phase 5 multipart protocol messages (create/upload/complete/abort/list/upload-part-copy requests + their responses).
- **`HealthServerTest`** — `/healthz`, `/readyz`, `/metrics`, and the Prometheus text rendering (labels, gauge, escaping).
- **`CandyboxCliTest`** — extra pre-network argument-handling cases.

## Coverage (aggregate UT + IT, the Codecov report)
| Metric | Before | After |
|---|---|---|
| Line | 80.1% | **90.2%** |
| Instruction | 79.5% | **90.5%** |

Notable per-class line-coverage gains:

| Class | Before | After |
|---|---|---|
| `NodeRequestHandler` | 39% | 89% |
| `CandyboxClient` | 47% | 86% |
| `CandyboxCli` | 17% | 84% |
| `CandyboxServer` | 0% | 65% |
| `HealthServer` | 48% | 96% |
| `BoxOwnership` | 68% | 88% |
| `MessageCodec` | 69% | 93% |

## Conventions followed
- ITs use the established wiring (`EmbeddedBookKeeper` + `TestingServer` + real node/transport/client), `*IT` suffix bound to failsafe, hand-written fakes only (no mocking frameworks), Apache-2.0 headers.
- The CLI/server ITs live in the `…client` / `…server` packages so they can reach the package-private `CandyboxCli.run` / `CandyboxServer.run` test entry points.

## Test plan
- `mvn verify` is green — unit suites plus all `*IT` integration tests on embedded BookKeeper/ZooKeeper pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)