### PR TITLE
docs: use the Candybox logo for the site brand and favicon

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -29,6 +29,8 @@ enableGitInfo = true
 
 [params]
   # hugo-book options — see https://github.com/alex-shpak/hugo-book#configuration
+  BookLogo = 'logo.svg'              # sidebar brand logo (served from static/logo.svg)
+  BookFavicon = 'logo.svg'           # browser-tab favicon (same SVG)
   BookTheme = 'auto'                 # light / dark / auto
   BookToC = true                     # per-page table of contents
   BookRepo = 'https://github.com/predatorray/candybox'

--- a/docs/static/logo.svg
+++ b/docs/static/logo.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Candybox logo">
+  <!-- Candies -->
+  <circle cx="96" cy="118" r="22" fill="#FF5C8A"/>
+  <circle cx="146" cy="104" r="17" fill="#FFC247"/>
+  <circle cx="138" cy="146" r="15" fill="#4ECDC4"/>
+  <circle cx="104" cy="156" r="12" fill="#7C6CFF"/>
+
+  <!-- Open box: square with top border missing -->
+  <path d="M60 145 L60 180 L180 180 L180 90"
+        fill="none" stroke="#3A6FF8" stroke-width="14"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds the Candybox logo to the documentation site (follow-up to #24).

## Changes

- **`docs/static/logo.svg`** — the project logo, copied from the `assets` branch.
- **`docs/config.toml`** — sets `BookLogo` so the logo appears next to the title in the sidebar brand, and `BookFavicon` so the same SVG is used as the browser-tab favicon.

Verified locally: the build copies `logo.svg` into the output, the sidebar renders ``'&lt;img src="/candybox/logo.svg"&gt;'``, and the favicon `<link rel="icon">` points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrEvU2tM8JaoZQgXotaPhH)_